### PR TITLE
Fix clean runner release restore

### DIFF
--- a/tools/BuildRelease.ps1
+++ b/tools/BuildRelease.ps1
@@ -47,7 +47,10 @@ foreach ($path in @($stagingRoot, $portableArchive, $setupPath, $checksumPath)) 
 New-Item -ItemType Directory -Force -Path $publishDirectory | Out-Null
 
 Write-Host "Publishing Captail $Version..."
-dotnet restore $project --locked-mode --artifacts-path $dotnetArtifacts
+dotnet restore $project `
+    --locked-mode `
+    --runtime win-x64 `
+    --artifacts-path $dotnetArtifacts
 if ($LASTEXITCODE -ne 0) {
     throw "dotnet restore failed with exit code $LASTEXITCODE."
 }


### PR DESCRIPTION
## Summary

Restore the .NET runtime packs for `win-x64` before running self-contained publish with `--no-restore`.

## Root cause

The release script restored without a runtime identifier, then published with `-r win-x64 --no-restore`. Developer machines with cached runtime packs passed, while a clean GitHub runner failed with `NETSDK1112` for `Microsoft.NETCore.App.Runtime.win-x64` and `Microsoft.WindowsDesktop.App.Runtime.win-x64`.

## Validation

- reproduced from failed release run 29939258182
- rebuilt the 0.1.2 portable package using a fresh artifacts directory
- restore, self-contained publish, native bridge build, ZIP creation, and checksum generation passed

After merge, the 0.1.2 release workflow will be dispatched again.