### PR TITLE
Fix Windows update file lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable user-facing changes are documented here.
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-08-02
+
+### Fixed
+
+- Update downloads now close their file handles before promoting verified packages or replacing an invalid cached package, preventing Windows file-lock errors during one-click updates.
+
+### Upgrade note
+
+- Captail 0.1.3 and 0.1.4 cannot complete an in-app update because the bug is inside those installed versions. Download and run the 0.1.5 Setup EXE once; later in-app updates will work normally.
+
 ## [0.1.3] - 2026-07-26
 
 ### Added

--- a/src/Captail/Captail.csproj
+++ b/src/Captail/Captail.csproj
@@ -14,7 +14,7 @@
     <Product>Captail</Product>
     <RootNamespace>Captail</RootNamespace>
     <ApplicationIcon>Assets\Captail.ico</ApplicationIcon>
-    <Version>0.1.4</Version>
+    <Version>0.1.5</Version>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
 

--- a/src/Captail/UpdateService.cs
+++ b/src/Captail/UpdateService.cs
@@ -422,16 +422,21 @@ internal sealed class UpdateService
             if (File.Exists(destinationPath) &&
                 new FileInfo(destinationPath).Length == asset.Size)
             {
-                await using var cachedFile = new FileStream(
-                    destinationPath,
-                    FileMode.Open,
-                    FileAccess.Read,
-                    FileShare.Read,
-                    128 * 1024,
-                    FileOptions.Asynchronous | FileOptions.SequentialScan);
-                byte[] cachedHash = await SHA256.HashDataAsync(
-                    cachedFile,
-                    cancellationToken);
+                byte[] cachedHash;
+                await using (var cachedFile = new FileStream(
+                                 destinationPath,
+                                 FileMode.Open,
+                                 FileAccess.Read,
+                                 FileShare.Read,
+                                 128 * 1024,
+                                 FileOptions.Asynchronous |
+                                 FileOptions.SequentialScan))
+                {
+                    cachedHash = await SHA256.HashDataAsync(
+                        cachedFile,
+                        cancellationToken);
+                }
+
                 if (CryptographicOperations.FixedTimeEquals(
                         Encoding.ASCII.GetBytes(
                             Convert.ToHexString(cachedHash)
@@ -460,65 +465,69 @@ internal sealed class UpdateService
                     "Downloaded update size does not match release metadata.");
             }
 
-            await using Stream source =
-                await response.Content.ReadAsStreamAsync(cancellationToken);
-            await using var destination = new FileStream(
-                temporaryPath,
-                FileMode.Create,
-                FileAccess.Write,
-                FileShare.None,
-                128 * 1024,
-                FileOptions.Asynchronous | FileOptions.SequentialScan);
-            using IncrementalHash hash =
-                IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
-
-            byte[] buffer = new byte[128 * 1024];
-            long total = 0;
-            int lastProgress = -1;
-            while (true)
+            await using (Stream source =
+                         await response.Content.ReadAsStreamAsync(
+                             cancellationToken))
+            await using (var destination = new FileStream(
+                             temporaryPath,
+                             FileMode.Create,
+                             FileAccess.Write,
+                             FileShare.None,
+                             128 * 1024,
+                             FileOptions.Asynchronous |
+                             FileOptions.SequentialScan))
             {
-                int read = await source.ReadAsync(
-                    buffer,
-                    cancellationToken);
-                if (read == 0)
-                    break;
-                total += read;
-                if (total > asset.Size || total > MaximumAssetBytes)
+                using IncrementalHash hash =
+                    IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+
+                byte[] buffer = new byte[128 * 1024];
+                long total = 0;
+                int lastProgress = -1;
+                while (true)
+                {
+                    int read = await source.ReadAsync(
+                        buffer,
+                        cancellationToken);
+                    if (read == 0)
+                        break;
+                    total += read;
+                    if (total > asset.Size || total > MaximumAssetBytes)
+                    {
+                        throw new InvalidDataException(
+                            "Downloaded update exceeds expected size.");
+                    }
+                    hash.AppendData(buffer, 0, read);
+                    await destination.WriteAsync(
+                        buffer.AsMemory(0, read),
+                        cancellationToken);
+
+                    int percent = (int)Math.Clamp(
+                        total * 100L / asset.Size,
+                        0,
+                        100);
+                    if (percent != lastProgress)
+                    {
+                        progress?.Report(percent);
+                        lastProgress = percent;
+                    }
+                }
+                await destination.FlushAsync(cancellationToken);
+
+                if (total != asset.Size)
                 {
                     throw new InvalidDataException(
-                        "Downloaded update exceeds expected size.");
+                        "Downloaded update is incomplete.");
                 }
-                hash.AppendData(buffer, 0, read);
-                await destination.WriteAsync(
-                    buffer.AsMemory(0, read),
-                    cancellationToken);
-
-                int percent = (int)Math.Clamp(
-                    total * 100L / asset.Size,
-                    0,
-                    100);
-                if (percent != lastProgress)
+                string actualHash =
+                    Convert.ToHexString(hash.GetHashAndReset())
+                        .ToLowerInvariant();
+                if (!CryptographicOperations.FixedTimeEquals(
+                        Encoding.ASCII.GetBytes(actualHash),
+                        Encoding.ASCII.GetBytes(expectedHash)))
                 {
-                    progress?.Report(percent);
-                    lastProgress = percent;
+                    throw new InvalidDataException(
+                        "Downloaded update failed SHA-256 verification.");
                 }
-            }
-            await destination.FlushAsync(cancellationToken);
-
-            if (total != asset.Size)
-            {
-                throw new InvalidDataException(
-                    "Downloaded update is incomplete.");
-            }
-            string actualHash =
-                Convert.ToHexString(hash.GetHashAndReset())
-                    .ToLowerInvariant();
-            if (!CryptographicOperations.FixedTimeEquals(
-                    Encoding.ASCII.GetBytes(actualHash),
-                    Encoding.ASCII.GetBytes(expectedHash)))
-            {
-                throw new InvalidDataException(
-                    "Downloaded update failed SHA-256 verification.");
             }
 
             File.Move(temporaryPath, destinationPath, overwrite: true);


### PR DESCRIPTION
## What changed

- close cached-package streams before deleting invalid cache entries
- close download streams before promoting verified `.download` files
- bump Captail to 0.1.5
- document the one-time manual upgrade required for 0.1.3 and 0.1.4

## Root cause

`DownloadVerifiedAsync` opened the temporary package with `FileShare.None` and called `File.Move` before the stream left its `await using` scope. Windows therefore rejected Captail's own rename with `ERROR_SHARING_VIOLATION`. The invalid-cache path had the same lifetime issue before `File.Delete`.

## User impact

One-click updates work normally starting with 0.1.5. Users already running 0.1.3 or 0.1.4 must install 0.1.5 manually once because the faulty updater is part of their installed binary.

## Validation

- deterministic update-download regression: download, SHA-256 verification, promotion, corrupt-cache replacement
- Debug build: 0 warnings, 0 errors
- Release build: 0 warnings, 0 errors
- `dotnet format --verify-no-changes`
- NuGet transitive vulnerability audit: clean