### PR TITLE
Skip CI for documentation-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## What changed

- skip the Windows Build workflow when a push or pull request changes only files under `docs/**`
- skip the same workflow for Markdown-only changes
- keep CI enabled for application assets, source code, dependencies, installers, tools, and workflow files

## Why

The workflow currently runs on every push to `main`, including screenshot-only commits. GitHub Actions treats every repository commit equally unless path filters are configured.

## Validation

- workflow diff contains valid `paths-ignore` filters for both `push` and `pull_request`
- whitespace validation passed
- this PR intentionally changes the workflow itself, so its normal checks still run