### PR TITLE
Add Microsoft Store packaging and privacy policy

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,117 @@
+# Captail Privacy Policy
+
+Effective date: August 3, 2026
+
+This policy applies to the Captail desktop application and its official
+Microsoft Store and GitHub distributions.
+
+## Summary
+
+Captail records instant replays locally on your Windows PC. Captail does not
+sell personal information, include advertising or analytics, automatically
+upload recordings, or provide the developer with access to your captures.
+
+## Information processed locally
+
+Depending on the features you enable, Captail may process:
+
+- desktop, application, or game video frames;
+- desktop or game audio;
+- microphone audio;
+- monitor, audio-device, GPU, codec, and game-process information needed to
+  configure capture;
+- replay files and their technical metadata;
+- settings such as hotkeys, selected devices, and output folders.
+
+This information is processed on your device to maintain the replay buffer,
+save clips, organize recordings, show previews, and trim saved videos. Captail
+does not transmit captured video or audio to the developer or to a Captail
+cloud service.
+
+Captail does not attempt to bypass DRM or protected-media restrictions.
+Protected content may appear black or unavailable in recordings.
+
+## Local storage
+
+Saved replays are written to the folder you select. The rolling replay buffer
+is held locally and only becomes a normal video file when you save a replay.
+
+Captail stores configuration and diagnostic logs under its local application
+data. The logical log location is:
+
+```text
+%LOCALAPPDATA%\Captail\log.txt
+```
+
+Windows may map Store-package application data to a package-specific location.
+Logs can contain technical errors, device and GPU names, codec settings, game
+or process names, and local file paths. Logs do not intentionally contain raw
+video frames or recorded audio. Logs are not uploaded automatically. Review
+them and remove sensitive paths or names before attaching them to a public bug
+report.
+
+## Network access
+
+Captail has no telemetry, analytics, advertising, account, or cloud-storage
+service.
+
+The Microsoft Store build relies on Microsoft Store for application updates
+and does not check GitHub Releases for updates. Microsoft Store may process
+installation, licensing, update, and diagnostic information under Microsoft's
+own privacy terms.
+
+Installer and Portable builds distributed through GitHub may contact the
+GitHub Releases API to check for and download updates. Those requests identify
+the Captail version and necessarily expose network information such as the IP
+address to GitHub. GitHub processes that information under the
+[GitHub Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement).
+
+Opening a GitHub, support, or repository link from Captail launches your
+default web browser. The destination website then applies its own privacy
+policy.
+
+## Permissions
+
+Captail uses only permissions needed for its recording workflow, including:
+
+- screen and game capture;
+- system-audio and optional microphone capture;
+- global replay hotkeys;
+- access to folders selected for replay storage;
+- hardware encoder detection;
+- optional startup with Windows.
+
+Microphone recording and startup with Windows can be disabled in Captail's
+settings. Capture can be stopped at any time by turning Instant Replay off or
+exiting Captail.
+
+## Sharing and disclosure
+
+Captail does not sell or share local recordings, settings, or diagnostic logs.
+Information leaves your device only when you choose to share a replay or log,
+or when a non-Store build performs the GitHub update request described above.
+
+## Retention and deletion
+
+You control saved replay retention. Replays can be deleted from Captail or
+Windows File Explorer. Configuration and logs remain locally until you delete
+them or Windows removes the application's data. Uninstalling Captail does not
+guarantee removal of replay files stored in your chosen output folder.
+
+## Children's privacy
+
+Captail is a general-purpose recording utility and is not directed to children.
+The developer does not knowingly collect personal information from children.
+
+## Changes to this policy
+
+Material changes will be published in this file and recorded in the
+repository's Git history. The effective date above will be updated when the
+policy changes.
+
+## Contact
+
+For privacy questions, open an issue in the
+[Captail repository](https://github.com/FaulMit/captail/issues). Do not include
+recordings, logs, local paths, or other sensitive information in a public
+issue.

--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ Read [CONTRIBUTING.md](CONTRIBUTING.md) before submitting changes. Release maint
 
 Captail is licensed under [GNU GPL-2.0-or-later](LICENSE).
 
+Privacy details are documented in [PRIVACY.md](PRIVACY.md).
+
 Captail uses libobs and selected OBS Studio runtime components. See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
 
 Captail is not affiliated with or endorsed by NVIDIA or OBS Project. NVIDIA and ShadowPlay are trademarks of NVIDIA Corporation.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -76,3 +76,18 @@ Output is written to `artifacts\release\0.1.1`.
 - Major: breaking change (`0.x` → `1.0.0`)
 
 Never replace published binaries under an existing tag. Publish a new version.
+
+## Microsoft Store release
+
+Microsoft Store is a separate package channel. It must not be attached to a
+GitHub Release because Store installs, signs, and updates the package.
+
+Build an upload-ready package locally:
+
+```powershell
+.\tools\BuildStorePackage.ps1 -Version 0.1.5
+```
+
+Upload `artifacts\store\0.1.5\Captail-0.1.5.0-x64.msixupload` in Partner
+Center. Full identity, validation, update-channel, and submission instructions
+are in [`packaging/msix/README.md`](../packaging/msix/README.md).

--- a/packaging/msix/AppxManifest.xml.template
+++ b/packaging/msix/AppxManifest.xml.template
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
+  xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  IgnorableNamespaces="uap uap10 desktop rescap">
+  <Identity
+    Name="faulmit.Captail"
+    Publisher="CN=1BD9448E-C83F-401D-B530-ED5258C6319A"
+    Version="__PACKAGE_VERSION__"
+    ProcessorArchitecture="x64" />
+  <Properties>
+    <DisplayName>Captail</DisplayName>
+    <PublisherDisplayName>faulmit</PublisherDisplayName>
+    <Description>Lightweight instant replay recorder for Windows.</Description>
+    <Logo>Assets\StoreLogo.png</Logo>
+  </Properties>
+  <Resources>
+    <Resource Language="en-us" />
+    <Resource Language="ru-ru" />
+  </Resources>
+  <Dependencies>
+    <TargetDeviceFamily
+      Name="Windows.Desktop"
+      MinVersion="10.0.19041.0"
+      MaxVersionTested="10.0.26100.0" />
+  </Dependencies>
+  <Applications>
+    <Application
+      Id="Captail"
+      Executable="Captail.exe"
+      uap10:RuntimeBehavior="packagedClassicApp"
+      uap10:TrustLevel="mediumIL">
+      <uap:VisualElements
+        DisplayName="Captail"
+        Description="Lightweight instant replay recorder for Windows."
+        BackgroundColor="transparent"
+        Square150x150Logo="Assets\Square150x150Logo.png"
+        Square44x44Logo="Assets\Square44x44Logo.png">
+        <uap:DefaultTile ShortName="Captail" />
+      </uap:VisualElements>
+      <Extensions>
+        <desktop:Extension
+          Category="windows.startupTask"
+          Executable="Captail.exe"
+          EntryPoint="Windows.FullTrustApplication">
+          <desktop:StartupTask
+            TaskId="CaptailStartup"
+            Enabled="false"
+            DisplayName="Captail" />
+        </desktop:Extension>
+      </Extensions>
+    </Application>
+  </Applications>
+  <Capabilities>
+    <rescap:Capability Name="runFullTrust" />
+    <DeviceCapability Name="microphone" />
+  </Capabilities>
+</Package>

--- a/packaging/msix/README.md
+++ b/packaging/msix/README.md
@@ -1,0 +1,64 @@
+# Microsoft Store package
+
+This package channel is separate from Captail's GitHub Installer and Portable
+releases. Microsoft Store installs and updates this build. Captail's GitHub
+self-updater is disabled at compile time and guarded again at runtime whenever
+Windows reports package identity.
+
+## Partner Center identity
+
+- Package name: `faulmit.Captail`
+- Publisher: `CN=1BD9448E-C83F-401D-B530-ED5258C6319A`
+- Publisher display name: `faulmit`
+- Package family name: `faulmit.Captail_ryepxmzt2jqew`
+- Store product ID: `9PKVNVLKPTPS`
+
+Do not change package name or publisher. Partner Center rejects packages whose
+manifest identity does not match the reserved product.
+
+## Build
+
+From repository root:
+
+```powershell
+.\tools\BuildStorePackage.ps1 -Version 0.1.5
+```
+
+Output:
+
+```text
+artifacts\store\0.1.5\Captail-0.1.5.0-x64.msix
+artifacts\store\0.1.5\Captail-0.1.5.0-x64.msixupload
+artifacts\store\0.1.5\SHA256SUMS.txt
+```
+
+Upload `.msixupload` on Partner Center's **Packages** page. Do not publish this
+artifact as a GitHub Release. Microsoft Store signs the accepted package for
+distribution.
+
+Generated package is intentionally unsigned. It is ready for Partner Center,
+but Windows will not allow direct sideloading until a trusted test certificate
+is applied. Store customers receive Microsoft's signed package after
+certification.
+
+## Versioning
+
+MSIX requires four numeric components. Captail `0.1.5` becomes package version
+`0.1.5.0`. Every Store submission must use a strictly higher package version.
+Never reuse a version already submitted to Partner Center.
+
+## Store-specific behavior
+
+- Updates are delivered only by Microsoft Store.
+- Footer shows `Microsoft Store` instead of an update action.
+- Startup uses the package `windows.startupTask` extension.
+- Installer and Portable builds continue using GitHub Releases and HKCU Run.
+
+## Before submission
+
+1. Build package from clean `main` commit.
+2. Check `SHA256SUMS.txt` and inspect generated manifest identity.
+3. Test install, first launch, tray, capture, replay save, microphone permission,
+   startup toggle, uninstall, and Store update from previous package version.
+4. Complete Partner Center privacy, age rating, properties, screenshots, and
+   certification notes.

--- a/src/Captail/App.xaml.cs
+++ b/src/Captail/App.xaml.cs
@@ -107,8 +107,9 @@ public partial class App : Application
             const bool previewGeometryTest = false;
 #endif
             bool backgroundLaunch = e.Args.Contains(
-                "--background",
-                StringComparer.OrdinalIgnoreCase);
+                    "--background",
+                    StringComparer.OrdinalIgnoreCase) ||
+                AppDistribution.IsStartupTaskActivation();
             bool shutdownExisting = e.Args.Contains(
                 "--shutdown-existing",
                 StringComparer.OrdinalIgnoreCase);
@@ -136,7 +137,7 @@ public partial class App : Application
             {
                 try
                 {
-                    Autostart.SetEnabled(true);
+                    await Autostart.SetEnabledAsync(true);
                 }
                 catch (Exception exception)
                 {
@@ -1307,6 +1308,9 @@ public partial class App : Application
         bool force,
         CancellationToken cancellationToken)
     {
+        if (AppDistribution.IsMicrosoftStore)
+            return Task.FromResult<UpdateRelease?>(null);
+
 #if DEBUG
         if (_qaUpdateAvailable)
         {
@@ -1568,7 +1572,7 @@ public partial class App : Application
 
         await _pipelineGate.WaitAsync();
         Config previous = _config!.Clone();
-        bool previousAutostart = Autostart.IsEnabled();
+        bool previousAutostart = await Autostart.IsEnabledAsync();
         bool wasRunning = IsReplayRunning;
         bool pipelineChanged = !previous.PipelineEquals(candidate);
         bool pipelineTouched = false;
@@ -1595,7 +1599,7 @@ public partial class App : Application
                         Localization.Text("L.Engine.BufferStartFailed"));
             }
 
-            Autostart.SetEnabled(autostartEnabled);
+            await Autostart.SetEnabledAsync(autostartEnabled);
             _config.Save();
             UpdateUiState();
 
@@ -1628,7 +1632,7 @@ public partial class App : Application
             }
             try
             {
-                Autostart.SetEnabled(previousAutostart);
+                await Autostart.SetEnabledAsync(previousAutostart);
             }
             catch (Exception rollbackException)
             {

--- a/src/Captail/AppDistribution.cs
+++ b/src/Captail/AppDistribution.cs
@@ -1,0 +1,47 @@
+using System.Runtime.InteropServices;
+using System.Text;
+using Windows.ApplicationModel.Activation;
+
+namespace Captail;
+
+internal static class AppDistribution
+{
+    internal const string StoreProductId = "9PKVNVLKPTPS";
+
+#if MICROSOFT_STORE
+    internal static bool IsMicrosoftStore { get; } = true;
+#else
+    internal static bool IsMicrosoftStore { get; } = HasPackageIdentity();
+#endif
+
+    internal static bool IsStartupTaskActivation()
+    {
+        if (!IsMicrosoftStore)
+            return false;
+
+        try
+        {
+            return Windows.ApplicationModel.AppInstance
+                .GetActivatedEventArgs()?.Kind == ActivationKind.StartupTask;
+        }
+        catch (Exception exception)
+        {
+            Log.Write($"Could not read package activation: {exception.Message}");
+            return false;
+        }
+    }
+
+    private static bool HasPackageIdentity()
+    {
+        int length = 0;
+        return GetCurrentPackageFullName(ref length, null) ==
+            ErrorInsufficientBuffer;
+    }
+
+    private const int ErrorInsufficientBuffer = 122;
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetCurrentPackageFullName(
+        ref int packageFullNameLength,
+        StringBuilder? packageFullName);
+}

--- a/src/Captail/Autostart.cs
+++ b/src/Captail/Autostart.cs
@@ -1,15 +1,25 @@
 using Microsoft.Win32;
+using Windows.ApplicationModel;
 
 namespace Captail;
 
-/// <summary>Per-user startup through HKCU\...\Run; administrator rights are not required.</summary>
+/// <summary>Per-user startup through MSIX StartupTask or HKCU Run.</summary>
 public static class Autostart
 {
     private const string RunKey = @"Software\Microsoft\Windows\CurrentVersion\Run";
     private const string ValueName = "Captail";
+    private const string StoreTaskId = "CaptailStartup";
 
-    public static bool IsEnabled()
+    public static async Task<bool> IsEnabledAsync()
     {
+        if (AppDistribution.IsMicrosoftStore)
+        {
+            StartupTask task = await StartupTask.GetAsync(StoreTaskId);
+            return task.State is
+                StartupTaskState.Enabled or
+                StartupTaskState.EnabledByPolicy;
+        }
+
         using var key = Registry.CurrentUser.OpenSubKey(RunKey);
         return string.Equals(
             ReadCommand(key),
@@ -19,12 +29,44 @@ public static class Autostart
 
     internal static bool HasEntry()
     {
+        if (AppDistribution.IsMicrosoftStore)
+            return false;
+
         using var key = Registry.CurrentUser.OpenSubKey(RunKey);
         return !string.IsNullOrWhiteSpace(ReadCommand(key));
     }
 
-    public static void SetEnabled(bool enabled)
+    public static async Task SetEnabledAsync(bool enabled)
     {
+        if (AppDistribution.IsMicrosoftStore)
+        {
+            StartupTask task = await StartupTask.GetAsync(StoreTaskId);
+            if (!enabled)
+            {
+                if (task.State is
+                    StartupTaskState.Enabled or
+                    StartupTaskState.EnabledByPolicy)
+                {
+                    task.Disable();
+                }
+                return;
+            }
+
+            StartupTaskState state = task.State is
+                StartupTaskState.Enabled or
+                StartupTaskState.EnabledByPolicy
+                    ? task.State
+                    : await task.RequestEnableAsync();
+            if (state is not
+                (StartupTaskState.Enabled or
+                 StartupTaskState.EnabledByPolicy))
+            {
+                throw new InvalidOperationException(
+                    Localization.Text("L.Error.AutostartDenied"));
+            }
+            return;
+        }
+
         using var key = Registry.CurrentUser.CreateSubKey(RunKey);
         if (enabled)
         {

--- a/src/Captail/Captail.csproj
+++ b/src/Captail/Captail.csproj
@@ -16,6 +16,7 @@
     <ApplicationIcon>Assets\Captail.ico</ApplicationIcon>
     <Version>0.1.5</Version>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+    <DefineConstants Condition="'$(MicrosoftStoreBuild)' == 'true'">$(DefineConstants);MICROSOFT_STORE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Captail/Languages/Strings.en.xaml
+++ b/src/Captail/Languages/Strings.en.xaml
@@ -24,6 +24,8 @@
   <sys:String x:Key="L.Update.CheckFailedTip">Could not check for updates · click to retry</sys:String>
   <sys:String x:Key="L.Update.CheckFailedTitle">Update check failed</sys:String>
   <sys:String x:Key="L.Update.InstallFailedTitle">Update failed</sys:String>
+  <sys:String x:Key="L.Update.StoreManaged">v{0} · Microsoft Store</sys:String>
+  <sys:String x:Key="L.Update.StoreManagedTip">Updates are delivered by Microsoft Store</sys:String>
 
   <sys:String x:Key="L.Status.Enabled">Instant Replay is on</sys:String>
   <sys:String x:Key="L.Status.Disabled">Instant Replay is off</sys:String>
@@ -195,6 +197,7 @@
   <sys:String x:Key="L.Error.CodecTitle">Codec unavailable</sys:String>
   <sys:String x:Key="L.Error.CodecMessage">Choose a codec supported by current GPU and driver.</sys:String>
   <sys:String x:Key="L.Error.AutostartTitle">Could not update startup</sys:String>
+  <sys:String x:Key="L.Error.AutostartDenied">Windows did not allow Captail to start automatically. Check Startup apps in Windows Settings.</sys:String>
   <sys:String x:Key="L.Error.AudioSourceTitle">Audio source unavailable</sys:String>
   <sys:String x:Key="L.Error.AudioSourceMessage">Change cancelled. Previous audio configuration restored.</sys:String>
   <sys:String x:Key="L.Error.SourceTitle">Could not change source</sys:String>

--- a/src/Captail/Languages/Strings.ru.xaml
+++ b/src/Captail/Languages/Strings.ru.xaml
@@ -24,6 +24,8 @@
   <sys:String x:Key="L.Update.CheckFailedTip">Не удалось проверить обновления · нажмите, чтобы повторить</sys:String>
   <sys:String x:Key="L.Update.CheckFailedTitle">Ошибка проверки обновлений</sys:String>
   <sys:String x:Key="L.Update.InstallFailedTitle">Ошибка обновления</sys:String>
+  <sys:String x:Key="L.Update.StoreManaged">v{0} · Microsoft Store</sys:String>
+  <sys:String x:Key="L.Update.StoreManagedTip">Обновления устанавливает Microsoft Store</sys:String>
 
   <sys:String x:Key="L.Status.Enabled">Мгновенный повтор включён</sys:String>
   <sys:String x:Key="L.Status.Disabled">Мгновенный повтор выключен</sys:String>
@@ -195,6 +197,7 @@
   <sys:String x:Key="L.Error.CodecTitle">Кодек недоступен</sys:String>
   <sys:String x:Key="L.Error.CodecMessage">Выберите кодек, который поддерживается текущим GPU и драйвером.</sys:String>
   <sys:String x:Key="L.Error.AutostartTitle">Не удалось изменить автозапуск</sys:String>
+  <sys:String x:Key="L.Error.AutostartDenied">Windows не разрешила автозапуск Captail. Проверьте раздел «Автозагрузка» в параметрах Windows.</sys:String>
   <sys:String x:Key="L.Error.AudioSourceTitle">Источник звука недоступен</sys:String>
   <sys:String x:Key="L.Error.AudioSourceMessage">Настройка отменена. Предыдущая конфигурация восстановлена.</sys:String>
   <sys:String x:Key="L.Error.SourceTitle">Не удалось изменить источник</sys:String>

--- a/src/Captail/SettingsWindow.xaml
+++ b/src/Captail/SettingsWindow.xaml
@@ -855,6 +855,7 @@
                     <Button x:Name="UpdateVersionButton"
                             HorizontalAlignment="Right"
                             Style="{StaticResource UpdateVersionButton}"
+                            ToolTipService.ShowOnDisabled="True"
                             Tag="current"
                             Click="UpdateVersion_Click">
                         <StackPanel Orientation="Horizontal">

--- a/src/Captail/SettingsWindow.xaml.cs
+++ b/src/Captail/SettingsWindow.xaml.cs
@@ -104,10 +104,12 @@ public partial class SettingsWindow : Window
             {
                 await Task.WhenAll(
                     LoadDeviceListsAsync(),
+                    LoadAutostartStateAsync(),
                     RefreshDiskAsync(),
                     RefreshReplayLibraryAsync());
             });
-            _ = CheckForUpdatesAsync(force: false);
+            if (!AppDistribution.IsMicrosoftStore)
+                _ = CheckForUpdatesAsync(force: false);
         };
         _diskTimer.Start();
     }
@@ -340,7 +342,6 @@ public partial class SettingsWindow : Window
             SystemVolumeSlider.Value = Math.Clamp(_config.SystemAudioVolume, 0, 100);
             MicVolumeSlider.Value = Math.Clamp(_config.MicrophoneVolume, 0, 100);
             MicBoostSlider.Value = Math.Clamp(_config.MicrophoneBoostDb, 0, 20);
-            AutostartBox.IsChecked = Autostart.IsEnabled();
             OrganizeByGameBox.IsChecked = _config.OrganizeReplaysByGame;
 
             _pendingSaveHotkey = _config.Hotkey;
@@ -516,6 +517,9 @@ public partial class SettingsWindow : Window
         object sender,
         RoutedEventArgs e)
     {
+        if (AppDistribution.IsMicrosoftStore)
+            return;
+
         if (_updateCheckInProgress || _updateInstallInProgress)
             return;
 
@@ -564,6 +568,9 @@ public partial class SettingsWindow : Window
 
     private async Task CheckForUpdatesAsync(bool force)
     {
+        if (AppDistribution.IsMicrosoftStore)
+            return;
+
         if (_updateCheckInProgress || _updateInstallInProgress)
             return;
 
@@ -624,6 +631,20 @@ public partial class SettingsWindow : Window
     private void RenderUpdateStatus()
     {
         string current = UpdateService.CurrentVersionText;
+        if (AppDistribution.IsMicrosoftStore)
+        {
+            UpdateVersionButton.IsEnabled = false;
+            UpdateVersionButton.Tag = "current";
+            UpdateStatusDot.Visibility = Visibility.Collapsed;
+            UpdateStatusText.Text = Localization.Format(
+                "L.Update.StoreManaged",
+                current);
+            UpdateVersionButton.ToolTip =
+                Localization.Text("L.Update.StoreManagedTip");
+            return;
+        }
+
+        UpdateVersionButton.IsEnabled = true;
         string? available = _availableUpdate is null
             ? null
             : UpdateService.FormatVersion(_availableUpdate.Version);
@@ -686,6 +707,20 @@ public partial class SettingsWindow : Window
                         "L.Update.UpToDateTip",
                         current);
                 break;
+        }
+    }
+
+    private async Task LoadAutostartStateAsync()
+    {
+        bool enabled = await Autostart.IsEnabledAsync();
+        _updatingUi = true;
+        try
+        {
+            AutostartBox.IsChecked = enabled;
+        }
+        finally
+        {
+            _updatingUi = false;
         }
     }
 

--- a/src/Captail/UpdateService.cs
+++ b/src/Captail/UpdateService.cs
@@ -74,6 +74,9 @@ internal sealed class UpdateService
         bool force,
         CancellationToken cancellationToken)
     {
+        if (AppDistribution.IsMicrosoftStore)
+            return null;
+
         if (!force &&
             _lastCheckUtc != default &&
             DateTime.UtcNow - _lastCheckUtc < CacheDuration)
@@ -140,6 +143,8 @@ internal sealed class UpdateService
         IProgress<int>? progress,
         CancellationToken cancellationToken)
     {
+        EnsureSelfUpdateAllowed();
+
         bool installed = IsInstalledBuild();
         UpdateAsset package = installed
             ? release.SetupAsset
@@ -202,6 +207,8 @@ internal sealed class UpdateService
 
     internal static void Launch(PreparedUpdate update)
     {
+        EnsureSelfUpdateAllowed();
+
         if (update.Kind == UpdatePackageKind.Installer)
         {
             if (Process.Start(new ProcessStartInfo
@@ -270,6 +277,15 @@ internal sealed class UpdateService
         {
             throw new InvalidOperationException(
                 "Windows did not start the Portable update helper.");
+        }
+    }
+
+    private static void EnsureSelfUpdateAllowed()
+    {
+        if (AppDistribution.IsMicrosoftStore)
+        {
+            throw new InvalidOperationException(
+                "Updates are managed by Microsoft Store.");
         }
     }
 

--- a/tools/BuildStorePackage.ps1
+++ b/tools/BuildStorePackage.ps1
@@ -1,0 +1,194 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidatePattern('^\d+\.\d+\.\d+$')]
+    [string]$Version,
+
+    [string]$OutputDirectory = "",
+
+    [string]$MakeAppxPath = ""
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot ".."))
+if (-not $OutputDirectory) {
+    $OutputDirectory = Join-Path $repoRoot "artifacts\store\$Version"
+}
+$outputRoot = [IO.Path]::GetFullPath($OutputDirectory)
+$repoPrefix = $repoRoot.TrimEnd(
+    [IO.Path]::DirectorySeparatorChar,
+    [IO.Path]::AltDirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar
+if (-not $outputRoot.StartsWith($repoPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+    throw "Store output must stay inside repository: $outputRoot"
+}
+
+$packageVersion = "$Version.0"
+$packageName = "Captail-$packageVersion-x64"
+$stagingRoot = Join-Path $outputRoot "staging"
+$dotnetArtifacts = Join-Path $stagingRoot "dotnet"
+$packageRoot = Join-Path $stagingRoot "package"
+$validationRoot = Join-Path $stagingRoot "validation"
+$msixPath = Join-Path $outputRoot "$packageName.msix"
+$uploadPath = Join-Path $outputRoot "$packageName.msixupload"
+$uploadZipPath = Join-Path $outputRoot "$packageName.zip"
+$checksumPath = Join-Path $outputRoot "SHA256SUMS.txt"
+$project = Join-Path $repoRoot "src\Captail\Captail.csproj"
+$manifestTemplate = Join-Path $repoRoot "packaging\msix\AppxManifest.xml.template"
+$iconPath = Join-Path $repoRoot "src\Captail\Assets\Captail.ico"
+
+foreach ($path in @(
+    $stagingRoot,
+    $msixPath,
+    $uploadPath,
+    $uploadZipPath,
+    $checksumPath)) {
+    $resolved = [IO.Path]::GetFullPath($path)
+    if (-not $resolved.StartsWith($outputRoot, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Refusing to clean path outside Store output: $resolved"
+    }
+    if (Test-Path -LiteralPath $resolved) {
+        Remove-Item -LiteralPath $resolved -Recurse -Force
+    }
+}
+New-Item -ItemType Directory -Force -Path $packageRoot | Out-Null
+
+if (-not $MakeAppxPath) {
+    $sdkBinRoot = Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\bin"
+    $MakeAppxPath = Get-ChildItem -LiteralPath $sdkBinRoot -Directory |
+        Where-Object { $_.Name -match '^\d+\.\d+\.\d+\.\d+$' } |
+        Sort-Object { [Version]$_.Name } -Descending |
+        ForEach-Object { Join-Path $_.FullName "x64\makeappx.exe" } |
+        Where-Object { Test-Path -LiteralPath $_ } |
+        Select-Object -First 1
+}
+if (-not $MakeAppxPath -or -not (Test-Path -LiteralPath $MakeAppxPath)) {
+    throw "MakeAppx.exe not found. Install Windows SDK or pass -MakeAppxPath."
+}
+
+Write-Host "Publishing Captail $Version for Microsoft Store..."
+dotnet restore $project `
+    --locked-mode `
+    --runtime win-x64 `
+    --artifacts-path $dotnetArtifacts
+if ($LASTEXITCODE -ne 0) {
+    throw "dotnet restore failed with exit code $LASTEXITCODE."
+}
+dotnet publish $project `
+    -c Release `
+    -r win-x64 `
+    --no-restore `
+    --artifacts-path $dotnetArtifacts `
+    --self-contained true `
+    -o $packageRoot `
+    -p:Version=$Version `
+    -p:MicrosoftStoreBuild=true `
+    -p:PublishSingleFile=true `
+    -p:IncludeNativeLibrariesForSelfExtract=true `
+    -p:EnableCompressionInSingleFile=true `
+    -p:PublishTrimmed=false `
+    -p:DebugType=None `
+    -p:DebugSymbols=false `
+    -p:ContinuousIntegrationBuild=true
+if ($LASTEXITCODE -ne 0) {
+    throw "dotnet publish failed with exit code $LASTEXITCODE."
+}
+
+foreach ($requiredPath in @(
+    (Join-Path $packageRoot "Captail.exe"),
+    (Join-Path $packageRoot "CaptailObsBridge.dll"),
+    (Join-Path $packageRoot "obs.dll"),
+    (Join-Path $packageRoot "ffmpeg\ffmpeg.exe"),
+    (Join-Path $packageRoot "ffmpeg\ffplay.exe"))) {
+    if (-not (Test-Path -LiteralPath $requiredPath)) {
+        throw "Store package dependency not found: $requiredPath"
+    }
+}
+
+Write-Host "Generating MSIX assets and manifest..."
+$assetsDirectory = Join-Path $packageRoot "Assets"
+New-Item -ItemType Directory -Force -Path $assetsDirectory | Out-Null
+Add-Type -AssemblyName System.Drawing.Common
+$sourceIcon = [Drawing.Icon]::new($iconPath, 256, 256)
+$sourceBitmap = $sourceIcon.ToBitmap()
+try {
+    foreach ($asset in @(
+        @{ Name = "Square44x44Logo.png"; Size = 44 },
+        @{ Name = "StoreLogo.png"; Size = 50 },
+        @{ Name = "Square150x150Logo.png"; Size = 150 })) {
+        $bitmap = [Drawing.Bitmap]::new($asset.Size, $asset.Size)
+        try {
+            $graphics = [Drawing.Graphics]::FromImage($bitmap)
+            try {
+                $graphics.Clear([Drawing.Color]::Transparent)
+                $graphics.CompositingQuality =
+                    [Drawing.Drawing2D.CompositingQuality]::HighQuality
+                $graphics.InterpolationMode =
+                    [Drawing.Drawing2D.InterpolationMode]::HighQualityBicubic
+                $graphics.SmoothingMode =
+                    [Drawing.Drawing2D.SmoothingMode]::HighQuality
+                $graphics.DrawImage(
+                    $sourceBitmap,
+                    [Drawing.Rectangle]::new(0, 0, $asset.Size, $asset.Size))
+            }
+            finally {
+                $graphics.Dispose()
+            }
+            $bitmap.Save(
+                (Join-Path $assetsDirectory $asset.Name),
+                [Drawing.Imaging.ImageFormat]::Png)
+        }
+        finally {
+            $bitmap.Dispose()
+        }
+    }
+}
+finally {
+    $sourceBitmap.Dispose()
+    $sourceIcon.Dispose()
+}
+
+$manifest = [IO.File]::ReadAllText($manifestTemplate)
+$manifest = $manifest.Replace("__PACKAGE_VERSION__", $packageVersion)
+$manifestPath = Join-Path $packageRoot "AppxManifest.xml"
+[IO.File]::WriteAllText(
+    $manifestPath,
+    $manifest,
+    [Text.UTF8Encoding]::new($false))
+
+Write-Host "Creating MSIX..."
+& $MakeAppxPath pack /d $packageRoot /p $msixPath /o
+if ($LASTEXITCODE -ne 0) {
+    throw "MakeAppx pack failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Validating generated package..."
+& $MakeAppxPath unpack /p $msixPath /d $validationRoot /o
+if ($LASTEXITCODE -ne 0) {
+    throw "MakeAppx unpack failed with exit code $LASTEXITCODE."
+}
+[xml]$validatedManifest = Get-Content -Raw (
+    Join-Path $validationRoot "AppxManifest.xml")
+$identity = $validatedManifest.Package.Identity
+if ($identity.Name -ne "faulmit.Captail" -or
+    $identity.Publisher -ne "CN=1BD9448E-C83F-401D-B530-ED5258C6319A" -or
+    $identity.Version -ne $packageVersion -or
+    $identity.ProcessorArchitecture -ne "x64") {
+    throw "Generated MSIX identity does not match Partner Center."
+}
+
+Write-Host "Creating Partner Center upload archive..."
+Compress-Archive -LiteralPath $msixPath `
+    -DestinationPath $uploadZipPath `
+    -CompressionLevel NoCompression
+Move-Item -LiteralPath $uploadZipPath -Destination $uploadPath
+
+$hashLines = foreach ($asset in @($msixPath, $uploadPath)) {
+    $hash = (Get-FileHash -LiteralPath $asset -Algorithm SHA256).Hash.ToLowerInvariant()
+    "$hash  $([IO.Path]::GetFileName($asset))"
+}
+Set-Content -LiteralPath $checksumPath -Value $hashLines -Encoding ascii
+
+Write-Host ""
+Write-Host "Microsoft Store package ready: $outputRoot"
+Get-ChildItem -LiteralPath $outputRoot -File |
+    Select-Object Name, Length


### PR DESCRIPTION
## Summary

- add a separate Microsoft Store MSIX packaging channel with the reserved Partner Center identity
- disable GitHub self-updates in Store builds and show Store-managed update status
- use the packaged Windows startup task while keeping HKCU startup for Installer and Portable builds
- add an English privacy policy covering local capture, logs, permissions, GitHub update checks, and Store updates
- link the privacy policy from the README and document future Store submissions

## Why

Captail needs an upload-ready Microsoft Store package without changing the existing GitHub Installer and Portable distribution channels. The Store submission also requires a public privacy policy because Captail can process screen, system-audio, and microphone data locally.

## Validation

- `dotnet build Captail.sln -c Release --no-restore`
- `dotnet format Captail.sln --verify-no-changes --no-restore`
- Store build completed with `tools/BuildStorePackage.ps1 -Version 0.1.5`
- MakeAppx pack and unpack validation passed
- generated identity matched `faulmit.Captail`, reserved publisher, version `0.1.5.0`, and x64
- English and Russian localization dictionaries remained in parity

## Notes

No MSIX or MSIXUPLOAD binaries are committed or attached to a GitHub Release. Microsoft Store remains responsible for signing and distributing the Store package.