### PR TITLE
Release Captail 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable user-facing changes are documented here.
 
 ## [Unreleased]
 
+## [0.1.6] - 2026-08-03
+
+### Added
+
+- Multi-track replays can now mix all enabled audio tracks into one playback-friendly track when saving or overwriting a trimmed clip. Video remains untouched; only audio is re-encoded.
+
+### Fixed
+
+- Settings selected in the window now remain visible when the recording pipeline rejects a change, making it possible to correct the failing option without re-entering resolution, audio, and other pending choices.
+- NVIDIA HEVC encoding no longer requests B-frames, fixing encoder startup on hardware such as the GeForce GTX 1080 where HEVC B-frames are unsupported.
+
 ## [0.1.5] - 2026-08-02
 
 ### Fixed

--- a/src/Captail/App.xaml.cs
+++ b/src/Captail/App.xaml.cs
@@ -86,6 +86,12 @@ public partial class App : Application
                     StringComparison.OrdinalIgnoreCase))
                 ?["--qa-clip-editor=".Length..];
             bool clipEditorTest = !string.IsNullOrWhiteSpace(clipEditorTestPath);
+            string? audioMixTestPath = e.Args
+                .FirstOrDefault(argument => argument.StartsWith(
+                    "--qa-audio-mix=",
+                    StringComparison.OrdinalIgnoreCase))
+                ?["--qa-audio-mix=".Length..];
+            bool audioMixTest = !string.IsNullOrWhiteSpace(audioMixTestPath);
             string? previewGeometryTestPath = e.Args
                 .FirstOrDefault(argument => argument.StartsWith(
                     "--qa-preview-geometry=",
@@ -104,6 +110,7 @@ public partial class App : Application
             const bool replaySegmentsTest = false;
             const bool updateCheckTest = false;
             const bool clipEditorTest = false;
+            const bool audioMixTest = false;
             const bool previewGeometryTest = false;
 #endif
             bool backgroundLaunch = e.Args.Contains(
@@ -118,7 +125,7 @@ public partial class App : Application
                     shutdownExisting,
                     _uiOnly || faultTest || codecTest || capabilityModelTest ||
                     gameCaptureTest || replaySegmentsTest || updateCheckTest ||
-                    clipEditorTest || previewGeometryTest))
+                    clipEditorTest || audioMixTest || previewGeometryTest))
             {
                 Shutdown();
                 return;
@@ -183,6 +190,11 @@ public partial class App : Application
             if (clipEditorTest)
             {
                 await RunClipEditorTestAsync(clipEditorTestPath!);
+                return;
+            }
+            if (audioMixTest)
+            {
+                await RunAudioMixTestAsync(audioMixTestPath!);
                 return;
             }
             if (previewGeometryTest)
@@ -251,6 +263,71 @@ public partial class App : Application
     }
 
 #if DEBUG
+    private async Task RunAudioMixTestAsync(string path)
+    {
+        string fullPath = Path.GetFullPath(path);
+        if (!File.Exists(fullPath))
+            throw new FileNotFoundException("QA replay does not exist.", fullPath);
+
+        string destination = Path.Combine(
+            Path.GetTempPath(),
+            $"captail_audio_mix_{Guid.NewGuid():N}{Path.GetExtension(fullPath)}");
+        try
+        {
+            var ffmpeg = new FfmpegAdapter();
+            TimeSpan duration = await ffmpeg.ReadDurationAsync(fullPath);
+            IReadOnlyList<AudioTrackInfo> sourceTracks =
+                await ffmpeg.ReadAudioTracksAsync(fullPath);
+            VideoStreamInfo? sourceVideo = await ffmpeg.ReadVideoInfoAsync(fullPath);
+            if (sourceTracks.Count < 2 || sourceVideo is null)
+                throw new InvalidOperationException(
+                    "QA replay requires video and at least two audio tracks.");
+
+            await ffmpeg.TrimCopyAsync(
+                fullPath,
+                destination,
+                TimeSpan.Zero,
+                duration,
+                sourceTracks.Select(track => track.StreamIndex).ToArray(),
+                mergeAudioTracks: true);
+
+            IReadOnlyList<AudioTrackInfo> mixedTracks =
+                await ffmpeg.ReadAudioTracksAsync(destination);
+            VideoStreamInfo? mixedVideo = await ffmpeg.ReadVideoInfoAsync(destination);
+            bool passed = mixedTracks.Count == 1 &&
+                mixedVideo is not null &&
+                mixedVideo.Codec.Equals(
+                    sourceVideo.Codec,
+                    StringComparison.OrdinalIgnoreCase) &&
+                mixedVideo.Width == sourceVideo.Width &&
+                mixedVideo.Height == sourceVideo.Height;
+            Log.Write(
+                $"AUDIO_MIX_TEST {(passed ? "PASS" : "FAIL")}: " +
+                $"sourceTracks={sourceTracks.Count}, mixedTracks={mixedTracks.Count}, " +
+                $"video={sourceVideo.Codec}/{mixedVideo?.Codec} " +
+                $"{sourceVideo.Width}x{sourceVideo.Height}/" +
+                $"{mixedVideo?.Width}x{mixedVideo?.Height}");
+            Shutdown(passed ? 0 : 16);
+        }
+        catch (Exception exception)
+        {
+            Log.Write($"AUDIO_MIX_TEST FAIL: {exception}");
+            Shutdown(16);
+        }
+        finally
+        {
+            try
+            {
+                if (File.Exists(destination))
+                    File.Delete(destination);
+            }
+            catch (Exception exception)
+            {
+                Log.Write($"Audio mix QA cleanup failed: {exception.Message}");
+            }
+        }
+    }
+
     private async Task RunClipEditorTestAsync(string path)
     {
         string fullPath = Path.GetFullPath(path);
@@ -373,6 +450,9 @@ public partial class App : Application
                 invalidConfig.Codec == "h264" &&
                 invalidConfig.SystemAudioVolume == 100 &&
                 invalidConfig.Hotkey == "Ctrl+Shift+F10" &&
+                ObsReplayEngine.RecommendedNvencBFrames("hevc", true) == 0 &&
+                ObsReplayEngine.RecommendedNvencBFrames("h264", true) == 2 &&
+                ObsReplayEngine.RecommendedNvencBFrames("h264", false) == 0 &&
                 invalidConfig.PipelineEquals(hotkeyOnlyChange) &&
                 !invalidConfig.PipelineEquals(pipelineChange);
             Log.Write(

--- a/src/Captail/Captail.csproj
+++ b/src/Captail/Captail.csproj
@@ -14,7 +14,7 @@
     <Product>Captail</Product>
     <RootNamespace>Captail</RootNamespace>
     <ApplicationIcon>Assets\Captail.ico</ApplicationIcon>
-    <Version>0.1.5</Version>
+    <Version>0.1.6</Version>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <DefineConstants Condition="'$(MicrosoftStoreBuild)' == 'true'">$(DefineConstants);MICROSOFT_STORE</DefineConstants>
   </PropertyGroup>

--- a/src/Captail/ClipEditorWindow.xaml
+++ b/src/Captail/ClipEditorWindow.xaml
@@ -11,6 +11,63 @@
         Foreground="{StaticResource TextPrimaryBrush}"
         FontFamily="{StaticResource FontUi}"
         PreviewKeyDown="Window_PreviewKeyDown">
+    <Window.Resources>
+        <Style x:Key="EditorMergeCheckBox" TargetType="CheckBox">
+            <Setter Property="Foreground" Value="{StaticResource TextPrimaryBrush}"/>
+            <Setter Property="Background" Value="{StaticResource BgControlBrush}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource BorderControlBrush}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="CheckBox">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="18"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <Border x:Name="Box" Width="18" Height="18" CornerRadius="5"
+                                    Background="{TemplateBinding Background}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="{TemplateBinding BorderThickness}">
+                                <Path x:Name="Check" Visibility="Collapsed"
+                                      Data="M4 9l3 3 7-7" Stroke="#07110E"
+                                      StrokeThickness="2" StrokeStartLineCap="Round"
+                                      StrokeEndLineCap="Round" StrokeLineJoin="Round"/>
+                            </Border>
+                            <ContentPresenter Grid.Column="1" Margin="8,0,0,0"
+                                              VerticalAlignment="Center"/>
+                            <Border x:Name="FocusBorder" Grid.ColumnSpan="2" Margin="-4"
+                                    BorderBrush="{StaticResource AccentBrush}"
+                                    BorderThickness="1" CornerRadius="7"
+                                    Visibility="Collapsed" IsHitTestVisible="False"/>
+                        </Grid>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Box" Property="BorderBrush"
+                                        Value="{StaticResource TextMutedBrush}"/>
+                            </Trigger>
+                            <Trigger Property="IsChecked" Value="True">
+                                <Setter TargetName="Box" Property="Background"
+                                        Value="{StaticResource AccentBrush}"/>
+                                <Setter TargetName="Box" Property="BorderBrush"
+                                        Value="{StaticResource AccentBrush}"/>
+                                <Setter TargetName="Check" Property="Visibility" Value="Visible"/>
+                            </Trigger>
+                            <Trigger Property="IsKeyboardFocused" Value="True">
+                                <Setter TargetName="FocusBorder" Property="Visibility" Value="Visible"/>
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter Property="Opacity" Value="0.45"/>
+                                <Setter Property="Cursor" Value="Arrow"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </Window.Resources>
     <Border Background="{StaticResource BgWindowGradient}"
             BorderBrush="{StaticResource WindowBorderBrush}" BorderThickness="1"
             CornerRadius="{StaticResource RadiusWindow}">
@@ -234,6 +291,19 @@
                                 Content="{DynamicResource L.Library.Overwrite}"
                                 Style="{StaticResource SubtleButton}" Padding="16,9"
                                 Click="RequestOverwrite_Click"/>
+                        <CheckBox x:Name="MergeAudioCheckBox" Margin="12,0,3,0"
+                                  Style="{StaticResource EditorMergeCheckBox}"
+                                  Visibility="Collapsed"
+                                  ToolTip="{DynamicResource L.Library.MergeAudioTip}"
+                                  ToolTipService.ShowOnDisabled="True">
+                            <StackPanel>
+                                <TextBlock Text="{DynamicResource L.Library.MergeAudio}"
+                                           FontSize="11" FontWeight="SemiBold"/>
+                                <TextBlock Text="{DynamicResource L.Library.MergeAudioSummary}"
+                                           FontSize="9.5"
+                                           Foreground="{StaticResource TextMutedBrush}"/>
+                            </StackPanel>
+                        </CheckBox>
                         <Button x:Name="SaveTrimButton" Margin="8,0,0,0"
                                 Content="{DynamicResource L.Library.SaveTrim}"
                                 Style="{StaticResource AccentButton}" Padding="18,9"
@@ -250,7 +320,8 @@
                     <StackPanel>
                         <TextBlock Text="{DynamicResource L.Library.OverwriteTitle}"
                                    FontSize="15" FontWeight="Bold"/>
-                        <TextBlock Text="{DynamicResource L.Library.OverwriteMessage}"
+                        <TextBlock x:Name="OverwriteMessageText"
+                                   Text="{DynamicResource L.Library.OverwriteMessage}"
                                    Margin="0,9,0,0" Style="{StaticResource SecondaryText}"
                                    TextWrapping="Wrap"/>
                         <TextBlock x:Name="OverwriteFileText" Margin="0,9,0,18"

--- a/src/Captail/ClipEditorWindow.xaml.cs
+++ b/src/Captail/ClipEditorWindow.xaml.cs
@@ -160,6 +160,7 @@ public partial class ClipEditorWindow : Window
             NoAudioText.Visibility = tracks.Count == 0
                 ? Visibility.Visible
                 : Visibility.Collapsed;
+            UpdateMergeAudioState();
 
             await Task.WhenAll(AudioTracks.Select(LoadWaveformAsync));
         }
@@ -171,6 +172,7 @@ public partial class ClipEditorWindow : Window
         {
             Log.Write($"Audio track inspection failed: {exception.Message}");
             NoAudioText.Visibility = Visibility.Visible;
+            MergeAudioCheckBox.Visibility = Visibility.Collapsed;
         }
     }
 
@@ -451,6 +453,7 @@ public partial class ClipEditorWindow : Window
 
     private async void AudioTrackToggle_Click(object sender, RoutedEventArgs e)
     {
+        UpdateMergeAudioState();
         if (!_playing || _playerLoading)
             return;
         double position = CurrentPlaybackPosition();
@@ -588,11 +591,28 @@ public partial class ClipEditorWindow : Window
             .Select(track => track.Track.StreamIndex)
             .ToArray();
 
+    private void UpdateMergeAudioState()
+    {
+        bool hasSeparateTracks = AudioTracks.Count > 1;
+        MergeAudioCheckBox.Visibility = hasSeparateTracks
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+        bool canMerge = hasSeparateTracks &&
+            AudioTracks.Count(track => track.IsSelected) > 1;
+        MergeAudioCheckBox.IsEnabled = canMerge;
+        if (!canMerge)
+            MergeAudioCheckBox.IsChecked = false;
+    }
+
     private async void SaveTrim_Click(object sender, RoutedEventArgs e) =>
         await SaveTrimAsync(overwrite: false);
 
     private void RequestOverwrite_Click(object sender, RoutedEventArgs e)
     {
+        OverwriteMessageText.Text = Localization.Text(
+            MergeAudioCheckBox.IsChecked == true
+                ? "L.Library.OverwriteMergeMessage"
+                : "L.Library.OverwriteMessage");
         OverwriteFileText.Text = _clip.Name;
         OverwriteConfirmOverlay.Visibility = Visibility.Visible;
     }
@@ -613,7 +633,12 @@ public partial class ClipEditorWindow : Window
     {
         SaveTrimButton.IsEnabled = false;
         OverwriteButton.IsEnabled = false;
-        EditorStatusText.Text = Localization.Text("L.Library.Trimming");
+        MergeAudioCheckBox.IsEnabled = false;
+        bool mergeAudioTracks = MergeAudioCheckBox.IsChecked == true;
+        EditorStatusText.Text = Localization.Text(
+            mergeAudioTracks
+                ? "L.Library.TrimmingMerge"
+                : "L.Library.Trimming");
         try
         {
             StopNativePlayback();
@@ -627,6 +652,7 @@ public partial class ClipEditorWindow : Window
                     start,
                     end,
                     audioStreams,
+                    mergeAudioTracks,
                     _lifetimeCts.Token)
                 : await _library.TrimAsync(
                     _rootDirectory,
@@ -634,6 +660,7 @@ public partial class ClipEditorWindow : Window
                     start,
                     end,
                     audioStreams,
+                    mergeAudioTracks,
                     _lifetimeCts.Token);
             _onSaved(path);
             DialogResult = true;
@@ -649,6 +676,7 @@ public partial class ClipEditorWindow : Window
             EditorStatusText.Text = exception.Message;
             SaveTrimButton.IsEnabled = true;
             OverwriteButton.IsEnabled = true;
+            UpdateMergeAudioState();
         }
     }
 

--- a/src/Captail/FfmpegAdapter.cs
+++ b/src/Captail/FfmpegAdapter.cs
@@ -221,6 +221,7 @@ public sealed class FfmpegAdapter
         TimeSpan start,
         TimeSpan end,
         IReadOnlyList<int>? audioStreamIndices = null,
+        bool mergeAudioTracks = false,
         CancellationToken cancellationToken = default)
     {
         if (start < TimeSpan.Zero || end <= start)
@@ -230,25 +231,58 @@ public sealed class FfmpegAdapter
             Path.GetExtension(destinationPath);
         try
         {
+            int[] selectedAudioStreams = audioStreamIndices?
+                .Distinct()
+                .ToArray() ?? [];
+            bool mixSelectedAudio = mergeAudioTracks && selectedAudioStreams.Length > 1;
             var arguments = new List<string>
             {
                 "-nostdin", "-hide_banner", "-loglevel", "error",
                 "-ss", start.TotalSeconds.ToString("0.###", CultureInfo.InvariantCulture),
                 "-i", sourcePath,
                 "-t", (end - start).TotalSeconds.ToString("0.###", CultureInfo.InvariantCulture),
-                "-map", "0:v:0",
-                "-c", "copy",
-                "-avoid_negative_ts", "make_zero",
             };
-            if (audioStreamIndices is null)
+            if (mixSelectedAudio)
             {
-                arguments.AddRange(["-map", "0:a?"]);
+                string inputs = string.Concat(
+                    selectedAudioStreams.Select(streamIndex => $"[0:{streamIndex}]"));
+                arguments.AddRange(
+                [
+                    "-filter_complex",
+                    $"{inputs}amix=inputs={selectedAudioStreams.Length}:" +
+                    "duration=longest:dropout_transition=0:normalize=0," +
+                    "alimiter=limit=0.95[mixed_audio]",
+                    "-map", "0:v:0",
+                    "-map", "[mixed_audio]",
+                    "-c:v", "copy",
+                ]);
+                bool opusOutput = Path.GetExtension(destinationPath).Equals(
+                    ".mkv",
+                    StringComparison.OrdinalIgnoreCase) ||
+                    Path.GetExtension(destinationPath).Equals(
+                        ".webm",
+                        StringComparison.OrdinalIgnoreCase);
+                arguments.AddRange(
+                [
+                    "-c:a", opusOutput ? "libopus" : "aac",
+                    "-b:a", opusOutput ? "192k" : "320k",
+                    "-metadata:s:a:0", "title=Mixed audio",
+                ]);
             }
             else
             {
-                foreach (int streamIndex in audioStreamIndices.Distinct())
-                    arguments.AddRange(["-map", $"0:{streamIndex}?"]);
+                arguments.AddRange(["-map", "0:v:0", "-c", "copy"]);
+                if (audioStreamIndices is null)
+                {
+                    arguments.AddRange(["-map", "0:a?"]);
+                }
+                else
+                {
+                    foreach (int streamIndex in selectedAudioStreams)
+                        arguments.AddRange(["-map", $"0:{streamIndex}?"]);
+                }
             }
+            arguments.AddRange(["-avoid_negative_ts", "make_zero"]);
             if (Path.GetExtension(destinationPath).Equals(".mp4", StringComparison.OrdinalIgnoreCase) ||
                 Path.GetExtension(destinationPath).Equals(".mov", StringComparison.OrdinalIgnoreCase))
             {
@@ -277,6 +311,7 @@ public sealed class FfmpegAdapter
         TimeSpan start,
         TimeSpan end,
         IReadOnlyList<int>? audioStreamIndices = null,
+        bool mergeAudioTracks = false,
         CancellationToken cancellationToken = default)
     {
         string directory = Path.GetDirectoryName(sourcePath)!;
@@ -292,6 +327,7 @@ public sealed class FfmpegAdapter
                 start,
                 end,
                 audioStreamIndices,
+                mergeAudioTracks,
                 cancellationToken);
             cancellationToken.ThrowIfCancellationRequested();
             File.Replace(

--- a/src/Captail/Languages/Strings.en.xaml
+++ b/src/Captail/Languages/Strings.en.xaml
@@ -155,6 +155,7 @@
   <sys:String x:Key="L.Library.Play">Play / pause</sys:String>
   <sys:String x:Key="L.Library.SaveTrim">Save trimmed copy</sys:String>
   <sys:String x:Key="L.Library.Trimming">Saving clip…</sys:String>
+  <sys:String x:Key="L.Library.TrimmingMerge">Trimming and mixing audio…</sys:String>
   <sys:String x:Key="L.Library.TrimHint">Creates a new file without re-encoding. Original replay stays untouched.</sys:String>
   <sys:String x:Key="L.Library.Trimmed">Trimmed replay saved</sys:String>
   <sys:String x:Key="L.Library.VideoTrack">VIDEO</sys:String>
@@ -165,12 +166,16 @@
   <sys:String x:Key="L.Library.SystemGameTrack">System / game</sys:String>
   <sys:String x:Key="L.Library.MicrophoneTrack">Microphone</sys:String>
   <sys:String x:Key="L.Library.AudioTrackNumber">Audio {0}</sys:String>
+  <sys:String x:Key="L.Library.MergeAudio">Merge audio tracks</sys:String>
+  <sys:String x:Key="L.Library.MergeAudioSummary">One playback track</sys:String>
+  <sys:String x:Key="L.Library.MergeAudioTip">Mixes all enabled audio tracks into one. Video is copied without re-encoding; audio is re-encoded.</sys:String>
   <sys:String x:Key="L.Library.RangeSummary">Selected · {0}</sys:String>
   <sys:String x:Key="L.Library.Back5">Back 5 seconds</sys:String>
   <sys:String x:Key="L.Library.Forward5">Forward 5 seconds</sys:String>
   <sys:String x:Key="L.Library.Overwrite">Overwrite</sys:String>
   <sys:String x:Key="L.Library.OverwriteTitle">Overwrite original replay?</sys:String>
   <sys:String x:Key="L.Library.OverwriteMessage">Selected range and enabled audio tracks will replace original file. This cannot be undone.</sys:String>
+  <sys:String x:Key="L.Library.OverwriteMergeMessage">Selected range will replace original file, and all enabled audio tracks will be mixed into one. This cannot be undone.</sys:String>
 
   <sys:String x:Key="L.Hotkey.SaveReplay">Save replay</sys:String>
   <sys:String x:Key="L.Hotkey.SaveHint">Saves current buffer</sys:String>

--- a/src/Captail/Languages/Strings.ru.xaml
+++ b/src/Captail/Languages/Strings.ru.xaml
@@ -155,6 +155,7 @@
   <sys:String x:Key="L.Library.Play">Воспроизвести / пауза</sys:String>
   <sys:String x:Key="L.Library.SaveTrim">Сохранить копию</sys:String>
   <sys:String x:Key="L.Library.Trimming">Сохраняю клип…</sys:String>
+  <sys:String x:Key="L.Library.TrimmingMerge">Обрезаю и объединяю звук…</sys:String>
   <sys:String x:Key="L.Library.TrimHint">Создаёт новый файл без перекодирования. Исходный повтор останется нетронутым.</sys:String>
   <sys:String x:Key="L.Library.Trimmed">Обрезанный повтор сохранён</sys:String>
   <sys:String x:Key="L.Library.VideoTrack">ВИДЕО</sys:String>
@@ -165,12 +166,16 @@
   <sys:String x:Key="L.Library.SystemGameTrack">Система / игра</sys:String>
   <sys:String x:Key="L.Library.MicrophoneTrack">Микрофон</sys:String>
   <sys:String x:Key="L.Library.AudioTrackNumber">Аудио {0}</sys:String>
+  <sys:String x:Key="L.Library.MergeAudio">Объединить дорожки</sys:String>
+  <sys:String x:Key="L.Library.MergeAudioSummary">Одна дорожка для плеера</sys:String>
+  <sys:String x:Key="L.Library.MergeAudioTip">Смешивает все включённые аудиодорожки в одну. Видео копируется без перекодирования, звук перекодируется.</sys:String>
   <sys:String x:Key="L.Library.RangeSummary">Выбрано · {0}</sys:String>
   <sys:String x:Key="L.Library.Back5">Назад на 5 секунд</sys:String>
   <sys:String x:Key="L.Library.Forward5">Вперёд на 5 секунд</sys:String>
   <sys:String x:Key="L.Library.Overwrite">Перезаписать</sys:String>
   <sys:String x:Key="L.Library.OverwriteTitle">Перезаписать исходный повтор?</sys:String>
   <sys:String x:Key="L.Library.OverwriteMessage">Выбранный участок и включённые аудиодорожки заменят исходный файл. Отменить это действие нельзя.</sys:String>
+  <sys:String x:Key="L.Library.OverwriteMergeMessage">Выбранный участок заменит исходный файл, а все включённые аудиодорожки будут смешаны в одну. Отменить это действие нельзя.</sys:String>
 
   <sys:String x:Key="L.Hotkey.SaveReplay">Сохранить повтор</sys:String>
   <sys:String x:Key="L.Hotkey.SaveHint">Сохраняет текущий буфер</sys:String>

--- a/src/Captail/ObsReplayEngine.cs
+++ b/src/Captail/ObsReplayEngine.cs
@@ -911,7 +911,7 @@ public sealed class ObsReplayEngine : IDisposable
         switch (encoder.Family)
         {
             case "nvenc":
-                ConfigureNvenc(settings, loadProfile);
+                ConfigureNvenc(settings, loadProfile, encoder.Codec);
                 break;
             case "amf":
                 ConfigureAmf(settings, loadProfile);
@@ -931,7 +931,8 @@ public sealed class ObsReplayEngine : IDisposable
 
     private static void ConfigureNvenc(
         nint settings,
-        EncoderLoadProfile loadProfile)
+        EncoderLoadProfile loadProfile,
+        string codec)
     {
         ObsNative.obs_data_set_string(
             settings,
@@ -955,8 +956,16 @@ public sealed class ObsReplayEngine : IDisposable
         ObsNative.obs_data_set_int(
             settings,
             "bf",
-            loadProfile == EncoderLoadProfile.Standard ? 2 : 0);
+            RecommendedNvencBFrames(
+                codec,
+                loadProfile == EncoderLoadProfile.Standard));
     }
+
+    internal static int RecommendedNvencBFrames(string codec, bool standardLoad) =>
+        standardLoad &&
+        !codec.Equals("hevc", StringComparison.OrdinalIgnoreCase)
+            ? 2
+            : 0;
 
     private static void ConfigureAmf(
         nint settings,

--- a/src/Captail/ReplayLibrary.cs
+++ b/src/Captail/ReplayLibrary.cs
@@ -112,6 +112,7 @@ public sealed class ReplayLibrary
         TimeSpan start,
         TimeSpan end,
         IReadOnlyList<int>? audioStreamIndices = null,
+        bool mergeAudioTracks = false,
         CancellationToken cancellationToken = default)
     {
         string source = ValidateClipPath(rootDirectory, clip.Path);
@@ -133,6 +134,7 @@ public sealed class ReplayLibrary
             start,
             end,
             audioStreamIndices,
+            mergeAudioTracks,
             cancellationToken);
         return destination;
     }
@@ -143,6 +145,7 @@ public sealed class ReplayLibrary
         TimeSpan start,
         TimeSpan end,
         IReadOnlyList<int>? audioStreamIndices = null,
+        bool mergeAudioTracks = false,
         CancellationToken cancellationToken = default)
     {
         string source = ValidateClipPath(rootDirectory, clip.Path);
@@ -160,6 +163,7 @@ public sealed class ReplayLibrary
             start,
             end,
             audioStreamIndices,
+            mergeAudioTracks,
             cancellationToken);
         return source;
     }

--- a/src/Captail/SettingsWindow.xaml.cs
+++ b/src/Captail/SettingsWindow.xaml.cs
@@ -1130,10 +1130,8 @@ public partial class SettingsWindow : Window
             if (!await _applySettings(
                     candidate,
                     AutostartBox.IsChecked == true))
-            {
-                LoadSettingsControls();
+                // Keep pending choices visible so the failing setting can be corrected.
                 return;
-            }
 
             Applied = true;
             _ = RefreshDiskAsync();
@@ -1145,7 +1143,6 @@ public partial class SettingsWindow : Window
             ShowError(
                 Localization.Text("L.Error.Attention"),
                 exception.Message);
-            LoadSettingsControls();
         }
         finally
         {


### PR DESCRIPTION
## What changed

- add an optional, localized **Merge audio tracks** control beside clip saving
- mix enabled tracks into one playback-friendly AAC/Opus track while stream-copying video
- keep pending settings visible after a failed pipeline restart instead of reloading old values into the form
- disable NVIDIA HEVC B-frames for compatibility with hardware such as GeForce GTX 1080
- bump Captail to 0.1.6 and add user-facing changelog entries
- add deterministic audio-mix and NVENC compatibility QA coverage

## Root cause

Failed settings application correctly rolled back the active configuration, but the settings window then reloaded that configuration into every control. This made pending resolution, audio, and other selections appear to reset. Separately, Captail requested two HEVC B-frames from NVENC even on GPUs where that feature is unsupported.

## Validation

- Debug build: 0 warnings, 0 errors
- Release build: 0 warnings, 0 errors
- `dotnet format --verify-no-changes`
- no vulnerable direct or transitive NuGet packages
- audio mix QA: 2 source tracks → 1 output track; video codec and resolution preserved
- GPU capability QA
- real WPF editor inspection with one and two audio tracks
- English/Russian localization key parity
- `git diff --check`