### PR TITLE
Prepare Captail 0.1.8 Store release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,16 @@ jobs:
             throw "Capability model QA failed: $($process.ExitCode)"
           }
 
+      - name: Validate replay folder routing
+        shell: pwsh
+        run: |
+          $exe = Resolve-Path './src/Captail/bin/Debug/net9.0-windows10.0.22621.0/win-x64/Captail.exe'
+          $process = Start-Process -FilePath $exe -ArgumentList '--qa-replay-routing' `
+            -Wait -PassThru
+          if ($process.ExitCode -ne 0) {
+            throw "Replay routing QA failed: $($process.ExitCode)"
+          }
+
       - name: Validate localization dictionaries
         shell: pwsh
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,6 +174,16 @@ jobs:
           if (-not (Test-Path -LiteralPath $uninstaller)) {
             throw "Installer did not create an uninstaller."
           }
+
+          $app = Start-Process `
+            -FilePath (Join-Path $installDirectory "Captail.exe") `
+            -ArgumentList "--background" `
+            -PassThru
+          Start-Sleep -Seconds 2
+          if ($app.HasExited) {
+            throw "Installed Captail exited before uninstall QA."
+          }
+
           $uninstall = Start-Process -FilePath $uninstaller -Wait -PassThru -ArgumentList @(
             "/VERYSILENT",
             "/SUPPRESSMSGBOXES",
@@ -184,6 +194,17 @@ jobs:
           }
           if (Test-Path -LiteralPath (Join-Path $installDirectory "Captail.exe")) {
             throw "Captail.exe remains after uninstall."
+          }
+          $app.Refresh()
+          if (-not $app.HasExited) {
+            throw "Captail process remains after uninstall."
+          }
+          foreach ($dataDirectory in @(
+            (Join-Path $env:LOCALAPPDATA "Captail"),
+            (Join-Path $env:APPDATA "Captail"))) {
+            if (Test-Path -LiteralPath $dataDirectory) {
+              throw "Captail data remains after uninstall: $dataDirectory"
+            }
           }
 
       - name: Verify SHA-256 checksums

--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -1,0 +1,236 @@
+name: Microsoft Store release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Semantic version without the v prefix, for example 0.1.8
+        required: true
+        type: string
+      mode:
+        description: Build only, upload a Partner Center draft, or submit for certification
+        required: true
+        default: build-only
+        type: choice
+        options:
+          - build-only
+          - draft
+          - submit
+
+permissions:
+  contents: read
+
+concurrency:
+  group: microsoft-store-release
+  cancel-in-progress: false
+
+env:
+  RELEASE_VERSION: ${{ inputs.version }}
+  STORE_OUTPUT: artifacts/store/${{ inputs.version }}
+
+jobs:
+  build:
+    name: Build and validate MSIX
+    runs-on: windows-2022
+    timeout-minutes: 45
+
+    steps:
+      - name: Validate release inputs
+        shell: pwsh
+        env:
+          RELEASE_MODE: ${{ inputs.mode }}
+        run: |
+          if ($env:RELEASE_VERSION -notmatch '^\d+\.\d+\.\d+$') {
+            throw "Invalid semantic version: $env:RELEASE_VERSION"
+          }
+          if ($env:RELEASE_MODE -notin @('build-only', 'draft', 'submit')) {
+            throw "Invalid release mode: $env:RELEASE_MODE"
+          }
+
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          dotnet-version: 9.0.x
+          cache: true
+          cache-dependency-path: src/Captail/packages.lock.json
+
+      - name: Acquire minimal OBS runtime
+        shell: pwsh
+        run: ./tools/AcquireObsRuntime.ps1
+
+      - name: Build Microsoft Store package
+        shell: pwsh
+        run: |
+          ./tools/BuildStorePackage.ps1 `
+            -Version $env:RELEASE_VERSION `
+            -OutputDirectory $env:STORE_OUTPUT
+
+      - name: Verify Store upload artifact
+        shell: pwsh
+        run: |
+          $upload = Join-Path $env:STORE_OUTPUT `
+            "Captail-$($env:RELEASE_VERSION).0-x64.msixupload"
+          $checksumFile = Join-Path $env:STORE_OUTPUT 'SHA256SUMS.txt'
+          if (-not (Test-Path -LiteralPath $upload)) {
+            throw "Store upload package not found: $upload"
+          }
+          if (-not (Test-Path -LiteralPath $checksumFile)) {
+            throw "Store checksum file not found: $checksumFile"
+          }
+
+          $expectedName = [IO.Path]::GetFileName($upload)
+          $checksumLine = Get-Content -LiteralPath $checksumFile |
+            Where-Object { $_ -match "^[0-9a-f]{64}  $([Regex]::Escape($expectedName))$" } |
+            Select-Object -First 1
+          if (-not $checksumLine) {
+            throw "Checksum entry not found for $expectedName."
+          }
+
+          $expectedHash = ($checksumLine -split '  ', 2)[0]
+          $actualHash = (Get-FileHash -LiteralPath $upload -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actualHash -ne $expectedHash) {
+            throw "Store upload checksum mismatch: $actualHash"
+          }
+          Write-Host "Verified $expectedName ($actualHash)"
+
+      - name: Upload Store package
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: Captail-${{ inputs.version }}-Microsoft-Store
+          path: |
+            ${{ env.STORE_OUTPUT }}/Captail-${{ inputs.version }}.0-x64.msixupload
+            ${{ env.STORE_OUTPUT }}/SHA256SUMS.txt
+          if-no-files-found: error
+          retention-days: 3
+
+  publish:
+    name: Publish to Partner Center
+    needs: build
+    if: ${{ inputs.mode != 'build-only' }}
+    runs-on: windows-2022
+    timeout-minutes: 30
+    environment:
+      name: microsoft-store-production
+    env:
+      RELEASE_MODE: ${{ inputs.mode }}
+      STORE_PRODUCT_ID: ${{ vars.STORE_PRODUCT_ID }}
+      STORE_TENANT_ID: ${{ secrets.AZURE_AD_TENANT_ID }}
+      STORE_CLIENT_ID: ${{ secrets.AZURE_AD_APPLICATION_CLIENT_ID }}
+      STORE_CLIENT_SECRET: ${{ secrets.AZURE_AD_APPLICATION_SECRET }}
+      STORE_SELLER_ID: ${{ secrets.SELLER_ID }}
+
+    steps:
+      - name: Validate publishing context
+        shell: pwsh
+        run: |
+          if ($env:GITHUB_REF -ne 'refs/heads/main') {
+            throw "Partner Center uploads are allowed only from main; current ref: $env:GITHUB_REF"
+          }
+
+          $required = @{
+            STORE_PRODUCT_ID = $env:STORE_PRODUCT_ID
+            STORE_TENANT_ID = $env:STORE_TENANT_ID
+            STORE_CLIENT_ID = $env:STORE_CLIENT_ID
+            STORE_CLIENT_SECRET = $env:STORE_CLIENT_SECRET
+            STORE_SELLER_ID = $env:STORE_SELLER_ID
+          }
+          $missing = @($required.GetEnumerator() |
+            Where-Object { [string]::IsNullOrWhiteSpace([string]$_.Value) } |
+            ForEach-Object { $_.Key })
+          if ($missing.Count -gt 0) {
+            throw "Missing Microsoft Store environment values: $($missing -join ', ')"
+          }
+
+      - name: Download Store package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: Captail-${{ inputs.version }}-Microsoft-Store
+          path: store-package
+
+      - name: Verify downloaded package
+        id: package
+        shell: pwsh
+        run: |
+          $uploads = @(Get-ChildItem -LiteralPath 'store-package' `
+            -Filter '*.msixupload' -File)
+          $checksumFile = Join-Path 'store-package' 'SHA256SUMS.txt'
+          if ($uploads.Count -ne 1 -or -not (Test-Path -LiteralPath $checksumFile)) {
+            throw 'Downloaded Store artifact is incomplete.'
+          }
+          $upload = $uploads[0]
+
+          $checksumLine = Get-Content -LiteralPath $checksumFile |
+            Where-Object { $_ -match "^[0-9a-f]{64}  $([Regex]::Escape($upload.Name))$" } |
+            Select-Object -First 1
+          if (-not $checksumLine) {
+            throw "Checksum entry not found for $($upload.Name)."
+          }
+
+          $expectedHash = ($checksumLine -split '  ', 2)[0]
+          $actualHash = (Get-FileHash -LiteralPath $upload.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actualHash -ne $expectedHash) {
+            throw "Downloaded Store package checksum mismatch: $actualHash"
+          }
+          "path=$($upload.FullName)" >> $env:GITHUB_OUTPUT
+
+      - name: Set up Microsoft Store Developer CLI
+        uses: microsoft/microsoft-store-apppublisher@15abd1c50fcc164b19cb240fb04ef3c49bf715a2 # v1.1
+        with:
+          version: v0.3.9
+
+      - name: Authenticate with Partner Center
+        shell: pwsh
+        run: |
+          msstore reconfigure `
+            --tenantId "$env:STORE_TENANT_ID" `
+            --sellerId "$env:STORE_SELLER_ID" `
+            --clientId "$env:STORE_CLIENT_ID" `
+            --clientSecret "$env:STORE_CLIENT_SECRET"
+          if ($LASTEXITCODE -ne 0) {
+            throw "Microsoft Store authentication failed: $LASTEXITCODE"
+          }
+
+      - name: Upload package to Partner Center
+        shell: pwsh
+        env:
+          PACKAGE_PATH: ${{ steps.package.outputs.path }}
+        run: |
+          $arguments = @(
+            'publish',
+            $env:PACKAGE_PATH,
+            '-id',
+            $env:STORE_PRODUCT_ID
+          )
+          if ($env:RELEASE_MODE -eq 'draft') {
+            $arguments += '-nc'
+          }
+
+          & msstore @arguments
+          if ($LASTEXITCODE -ne 0) {
+            throw "Partner Center package upload failed: $LASTEXITCODE"
+          }
+
+      - name: Report submission status
+        shell: pwsh
+        run: |
+          & msstore submission status $env:STORE_PRODUCT_ID
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not read Partner Center submission status: $LASTEXITCODE"
+          }
+
+          $action = if ($env:RELEASE_MODE -eq 'draft') {
+            'uploaded as a Partner Center draft'
+          }
+          else {
+            'submitted to Microsoft certification'
+          }
+          @"
+          ## Captail $env:RELEASE_VERSION
+
+          Package $action.
+
+          Product ID: ``$env:STORE_PRODUCT_ID``
+          "@ >> $env:GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevented Microsoft Store builds from loading libobs media DLLs into the bundled FFmpeg tools, which could stop replay metadata, waveform, and trim operations before FFmpeg started.
+
 ## [0.1.7] - 2026-08-04
 
 ### Added

--- a/docs/MICROSOFT-STORE-RELEASES.md
+++ b/docs/MICROSOFT-STORE-RELEASES.md
@@ -1,0 +1,48 @@
+# Microsoft Store releases
+
+Captail Store packages are built and published by the `Microsoft Store release`
+GitHub Actions workflow. Store publishing is intentionally separate from the
+ordinary GitHub Release workflow.
+
+## One-time repository setup
+
+Create a GitHub environment named `microsoft-store-production` and add these
+environment secrets:
+
+- `AZURE_AD_TENANT_ID`
+- `AZURE_AD_APPLICATION_CLIENT_ID`
+- `AZURE_AD_APPLICATION_SECRET`
+- `SELLER_ID`
+
+Add this environment variable:
+
+- `STORE_PRODUCT_ID` = `9PKVNVLKPTPS`
+
+The Microsoft Entra application must be associated with the Partner Center
+account and assigned the `Manager` role. Rotate the client secret before its
+expiration date and update `AZURE_AD_APPLICATION_SECRET` in GitHub.
+
+## Publishing an update
+
+1. Merge the release-ready code into `main`.
+2. Open **Actions** and select **Microsoft Store release**.
+3. Select **Run workflow** from `main`.
+4. Enter the three-part version, for example `0.1.8`.
+5. Select one mode:
+   - `build-only`: build and validate the package without contacting Partner Center.
+   - `draft`: upload the package but leave the submission as a draft.
+   - `submit`: upload the package and submit it for Microsoft certification.
+6. Review the workflow summary and Partner Center submission status.
+
+The workflow stores the `.msixupload` package for three days. Microsoft Store
+certification and rollout continue in Partner Center after the workflow ends.
+
+## Safety rules
+
+- Partner Center uploads run only from `main`.
+- The `microsoft-store-production` environment gates access to Store credentials.
+- External actions and the Microsoft Store CLI version are pinned.
+- The package SHA-256 is verified before upload.
+- `build-only` is the default mode.
+- Never put Microsoft Entra credentials in source files, workflow inputs, logs,
+  issues, or pull requests.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -88,6 +88,9 @@ Build an upload-ready package locally:
 .\tools\BuildStorePackage.ps1 -Version 0.1.7
 ```
 
+Store packaging uses self-contained FFmpeg tools and rejects package-root DLL
+collisions before creating the Partner Center upload archive.
+
 Upload `artifacts\store\0.1.7\Captail-0.1.7.0-x64.msixupload` in Partner
 Center. Full identity, validation, update-channel, and submission instructions
 are in [`packaging/msix/README.md`](../packaging/msix/README.md).

--- a/installer/Captail.iss
+++ b/installer/Captail.iss
@@ -67,25 +67,46 @@ Name: "{autodesktop}\Captail"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktop
 [Registry]
 Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; ValueType: string; ValueName: "Captail"; ValueData: """{app}\{#MyAppExeName}"" --background"; Flags: uninsdeletevalue; Tasks: startup
 
+[UninstallDelete]
+Type: filesandordirs; Name: "{localappdata}\Captail"
+Type: filesandordirs; Name: "{userappdata}\Captail"
+
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "Launch Captail"; Flags: nowait postinstall skipifsilent
 
 [Code]
-function PrepareToInstall(var NeedsRestart: Boolean): String;
+function StopCaptail(): Boolean;
 var
   ResultCode: Integer;
   InstalledExe: String;
 begin
-  Result := '';
+  Result := True;
   InstalledExe := ExpandConstant('{app}\{#MyAppExeName}');
   if FileExists(InstalledExe) then
   begin
     if not Exec(InstalledExe, '--shutdown-existing', '', SW_HIDE,
       ewWaitUntilTerminated, ResultCode) then
-      Result := 'Could not ask Captail to stop before updating.'
+      Result := False
     else if ResultCode <> 0 then
-      Result := 'Captail is still busy. Wait for replay saving to finish, then retry.';
+      Result := False;
   end;
+end;
+
+function PrepareToInstall(var NeedsRestart: Boolean): String;
+begin
+  Result := '';
+  if not StopCaptail() then
+    Result := 'Captail is still busy. Wait for replay saving to finish, then retry.';
+end;
+
+function InitializeUninstall(): Boolean;
+begin
+  Result := StopCaptail();
+  if not Result then
+    MsgBox(
+      'Captail could not stop safely. Close any active save operation and retry.',
+      mbError,
+      MB_OK);
 end;
 
 procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);

--- a/packaging/msix/AppxManifest.xml.template
+++ b/packaging/msix/AppxManifest.xml.template
@@ -26,6 +26,10 @@
       Name="Windows.Desktop"
       MinVersion="10.0.19041.0"
       MaxVersionTested="10.0.26100.0" />
+    <PackageDependency
+      Name="Microsoft.VCLibs.140.00.UWPDesktop"
+      MinVersion="14.0.33728.0"
+      Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
   </Dependencies>
   <Applications>
     <Application

--- a/packaging/msix/README.md
+++ b/packaging/msix/README.md
@@ -44,6 +44,11 @@ but Windows will not allow direct sideloading until a trusted test certificate
 is applied. Store customers receive Microsoft's signed package after
 certification.
 
+Store packages use verified self-contained FFmpeg command-line tools. This
+prevents packaged-process DLL resolution from mixing FFmpeg with libobs media
+libraries that use the same file names. Package creation fails if duplicate
+libraries return or either command-line tool cannot start.
+
 ## Versioning
 
 MSIX requires four numeric components. Captail `0.1.7` becomes package version
@@ -61,7 +66,8 @@ Never reuse a version already submitted to Partner Center.
 
 1. Build package from clean `main` commit.
 2. Check `SHA256SUMS.txt` and inspect generated manifest identity.
-3. Test install, first launch, tray, capture, replay save, microphone permission,
-   startup toggle, uninstall, and Store update from previous package version.
+3. Test install, first launch, tray, capture, replay save, clip preview and trim,
+   microphone permission, startup toggle, uninstall, and Store update from the
+   previous package version.
 4. Complete Partner Center privacy, age rating, properties, screenshots, and
    certification notes.

--- a/src/Captail/App.xaml.cs
+++ b/src/Captail/App.xaml.cs
@@ -49,6 +49,7 @@ public partial class App : Application
     private string? _captureDescription;
     private int _exiting;
     private bool _shutdownExistingSucceeded = true;
+    private StorePackageLifecycle? _storePackageLifecycle;
 #if DEBUG
     private bool _qaUpdateAvailable;
 #endif
@@ -84,6 +85,9 @@ public partial class App : Application
                 StringComparer.OrdinalIgnoreCase);
             bool automaticCapturePolicyTest = e.Args.Contains(
                 "--qa-auto-capture-policy",
+                StringComparer.OrdinalIgnoreCase);
+            bool replayRoutingTest = e.Args.Contains(
+                "--qa-replay-routing",
                 StringComparer.OrdinalIgnoreCase);
             bool updateCheckTest = e.Args.Contains(
                 "--qa-update-check",
@@ -125,6 +129,7 @@ public partial class App : Application
             const bool replaySegmentsTest = false;
             const bool fileRetryTest = false;
             const bool automaticCapturePolicyTest = false;
+            const bool replayRoutingTest = false;
             const bool updateCheckTest = false;
             const bool clipEditorTest = false;
             const bool audioMixTest = false;
@@ -145,7 +150,7 @@ public partial class App : Application
                     gameCaptureTest || replaySegmentsTest || updateCheckTest ||
                     clipEditorTest || audioMixTest || previewGeometryTest ||
                     fileRetryTest || trimOverwriteTest ||
-                    automaticCapturePolicyTest))
+                    automaticCapturePolicyTest || replayRoutingTest))
             {
                 Shutdown();
                 return;
@@ -156,6 +161,9 @@ public partial class App : Application
                 return;
             }
 
+            AppDataPaths.PrepareStoreData();
+            _storePackageLifecycle = StorePackageLifecycle.Start(
+                OnStorePackageStopping);
             _config = Config.Load();
             Localization.SetLanguage(_config.Language);
             Localization.Changed += OnLanguageChanged;
@@ -207,6 +215,11 @@ public partial class App : Application
             if (automaticCapturePolicyTest)
             {
                 RunAutomaticCapturePolicyTest();
+                return;
+            }
+            if (replayRoutingTest)
+            {
+                RunReplayRoutingTest();
                 return;
             }
             if (updateCheckTest)
@@ -2177,6 +2190,108 @@ public partial class App : Application
     }
 
 #if DEBUG
+    private void RunReplayRoutingTest()
+    {
+        try
+        {
+            string? automaticGame =
+                ObsReplayEngine.ResolveReplayGameExecutable(
+                    isAutomaticCapture: true,
+                    automaticGameActive: true,
+                    activeGameExecutable: @"C:\Games\Counter-Strike 2\cs2.exe",
+                    isGameHooked: true,
+                    hookedExecutable: @"C:\Users\User\Telegram.exe");
+            string? automaticDesktop =
+                ObsReplayEngine.ResolveReplayGameExecutable(
+                    isAutomaticCapture: true,
+                    automaticGameActive: false,
+                    activeGameExecutable: "",
+                    isGameHooked: true,
+                    hookedExecutable: @"C:\Users\User\Telegram.exe");
+            string? manualGame =
+                ObsReplayEngine.ResolveReplayGameExecutable(
+                    isAutomaticCapture: false,
+                    automaticGameActive: false,
+                    activeGameExecutable: @"C:\Games\Counter-Strike 2\cs2.exe",
+                    isGameHooked: true,
+                    hookedExecutable: @"C:\Games\Counter-Strike 2\cs2.exe");
+            string? noHook =
+                ObsReplayEngine.ResolveReplayGameExecutable(
+                    isAutomaticCapture: false,
+                    automaticGameActive: false,
+                    activeGameExecutable: "",
+                    isGameHooked: false,
+                    hookedExecutable: "");
+
+            string root = Path.Combine(
+                Path.GetTempPath(),
+                "Captail",
+                $"routing_{Environment.ProcessId}");
+            Directory.CreateDirectory(root);
+            var config = new Config
+            {
+                OrganizeReplaysByGame = true,
+                OutputDirectory = root,
+            };
+            string automaticSource = Path.Combine(root, "automatic.mkv");
+            string desktopSource = Path.Combine(root, "desktop.mkv");
+            string manualSource = Path.Combine(root, "manual.mkv");
+            File.WriteAllBytes(automaticSource, [1]);
+            File.WriteAllBytes(desktopSource, [2]);
+            File.WriteAllBytes(manualSource, [3]);
+            string automaticDestination = ReplayPaths.RouteSavedReplay(
+                config,
+                automaticSource,
+                automaticGame);
+            string desktopDestination = ReplayPaths.RouteSavedReplay(
+                config,
+                desktopSource,
+                automaticDesktop);
+            string manualDestination = ReplayPaths.RouteSavedReplay(
+                config,
+                manualSource,
+                manualGame);
+
+            bool passed =
+                string.Equals(
+                    Path.GetFileName(automaticGame),
+                    "cs2.exe",
+                    StringComparison.OrdinalIgnoreCase) &&
+                automaticDesktop is null &&
+                string.Equals(
+                    Path.GetFileName(manualGame),
+                    "cs2.exe",
+                    StringComparison.OrdinalIgnoreCase) &&
+                noHook is null &&
+                string.Equals(
+                    Path.GetFileName(Path.GetDirectoryName(
+                        automaticDestination)),
+                    "cs2",
+                    StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(
+                    Path.GetDirectoryName(desktopDestination),
+                    root,
+                    StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(
+                    Path.GetFileName(Path.GetDirectoryName(manualDestination)),
+                    "cs2",
+                    StringComparison.OrdinalIgnoreCase);
+            Log.Write(
+                $"REPLAY_ROUTING_TEST {(passed ? "PASS" : "FAIL")}: " +
+                $"autoGame={automaticGame}, autoDesktop={automaticDesktop}, " +
+                $"manual={manualGame}, noHook={noHook}, " +
+                $"autoFolder={Path.GetDirectoryName(automaticDestination)}, " +
+                $"desktopFolder={Path.GetDirectoryName(desktopDestination)}");
+            Directory.Delete(root, recursive: true);
+            Shutdown(passed ? 0 : 24);
+        }
+        catch (Exception exception)
+        {
+            Log.Write($"REPLAY_ROUTING_TEST FAIL: {exception}");
+            Shutdown(24);
+        }
+    }
+
     private async void RunReplaySegmentsTest()
     {
         try
@@ -2332,6 +2447,35 @@ public partial class App : Application
         Shutdown();
     }
 
+    private void OnStorePackageStopping(string reason)
+    {
+        if (Dispatcher.HasShutdownStarted || Dispatcher.HasShutdownFinished)
+            return;
+
+        Log.Write($"Stopping Captail for Store package {reason}.");
+        if (Dispatcher.CheckAccess())
+        {
+            _ = RequestShutdownAsync();
+            return;
+        }
+
+        try
+        {
+            Task shutdown = Dispatcher.Invoke(
+                RequestShutdownAsync,
+                DispatcherPriority.Send);
+            if (!shutdown.Wait(TimeSpan.FromSeconds(15)))
+            {
+                Log.Write(
+                    "Store package shutdown did not finish within 15 seconds.");
+            }
+        }
+        catch (Exception exception)
+        {
+            Log.Write($"Store package shutdown failed: {exception.Message}");
+        }
+    }
+
     protected override void OnExit(ExitEventArgs e)
     {
         bool gracefulShutdownCompleted =
@@ -2342,6 +2486,8 @@ public partial class App : Application
         _updateShutdownTimer?.Stop();
         _activationServerCts?.Cancel();
         _activationServerCts?.Dispose();
+        _storePackageLifecycle?.Dispose();
+        _storePackageLifecycle = null;
         _settingsWindow?.Close();
         _hotkeys?.Dispose();
         _tray?.Dispose();

--- a/src/Captail/AppDataPaths.cs
+++ b/src/Captail/AppDataPaths.cs
@@ -1,0 +1,129 @@
+using System.IO;
+using Windows.Storage;
+
+namespace Captail;
+
+internal static class AppDataPaths
+{
+    private static readonly string LegacyLocalRoot = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "Captail");
+    private static readonly string LegacyRoamingRoot = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "Captail");
+
+    private static string StateRoot => AppDistribution.IsMicrosoftStore
+        ? ApplicationData.Current.LocalFolder.Path
+        : LegacyRoamingRoot;
+
+    private static string CacheRoot => AppDistribution.IsMicrosoftStore
+        ? ApplicationData.Current.LocalCacheFolder.Path
+        : LegacyLocalRoot;
+
+    internal static string ConfigFile => Path.Combine(StateRoot, "config.json");
+    internal static string LogFile => Path.Combine(CacheRoot, "log.txt");
+    internal static string ObsConfigDirectory => Path.Combine(CacheRoot, "obs");
+    internal static string ObsPluginCacheDirectory =>
+        Path.Combine(CacheRoot, "obs-plugin-cache");
+    internal static string ThumbnailDirectory =>
+        Path.Combine(CacheRoot, "thumbnails");
+
+    internal static void PrepareStoreData()
+    {
+        if (!AppDistribution.IsMicrosoftStore)
+            return;
+
+        Directory.CreateDirectory(StateRoot);
+        Directory.CreateDirectory(CacheRoot);
+        MigrateLegacyFile(
+            Path.Combine(LegacyRoamingRoot, "config.json"),
+            ConfigFile);
+        MigrateLegacyFile(
+            Path.Combine(LegacyRoamingRoot, "config.json.bak"),
+            ConfigFile + ".bak");
+
+        TryDeleteLegacyFile(Path.Combine(LegacyLocalRoot, "log.txt"));
+        foreach (string directory in new[]
+                 {
+                     "obs",
+                     "obs-plugin-cache",
+                     "thumbnails",
+                 })
+        {
+            TryDeleteLegacyDirectory(Path.Combine(LegacyLocalRoot, directory));
+        }
+
+        TryDeleteIfEmpty(LegacyRoamingRoot);
+        TryDeleteIfEmpty(LegacyLocalRoot);
+    }
+
+    private static void MigrateLegacyFile(string source, string destination)
+    {
+        if (!File.Exists(source))
+            return;
+
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+            if (!File.Exists(destination))
+                File.Move(source, destination);
+            else
+                File.Delete(source);
+        }
+        catch (IOException)
+        {
+            // A previous process can briefly retain its settings file.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Keep legacy data intact when migration is not permitted.
+        }
+    }
+
+    private static void TryDeleteLegacyFile(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    private static void TryDeleteLegacyDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    private static void TryDeleteIfEmpty(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path) &&
+                !Directory.EnumerateFileSystemEntries(path).Any())
+            {
+                Directory.Delete(path);
+            }
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/src/Captail/Captail.csproj
+++ b/src/Captail/Captail.csproj
@@ -14,7 +14,8 @@
     <Product>Captail</Product>
     <RootNamespace>Captail</RootNamespace>
     <ApplicationIcon>Assets\Captail.ico</ApplicationIcon>
-    <Version>0.1.7</Version>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <Version>0.1.8</Version>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <DefineConstants Condition="'$(MicrosoftStoreBuild)' == 'true'">$(DefineConstants);MICROSOFT_STORE</DefineConstants>
   </PropertyGroup>

--- a/src/Captail/Config.cs
+++ b/src/Captail/Config.cs
@@ -53,8 +53,7 @@ public sealed class Config
         Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyVideos), "Captail");
     public bool OrganizeReplaysByGame { get; set; }
     [JsonIgnore]
-    public static string ConfigPath =>
-        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Captail", "config.json");
+    public static string ConfigPath => AppDataPaths.ConfigFile;
     public static Config Load()
     {
         if (TryLoad(ConfigPath, out Config? config) && config is not null)

--- a/src/Captail/Log.cs
+++ b/src/Captail/Log.cs
@@ -7,9 +7,7 @@ public static class Log
     private static readonly Lock _lock = new();
     private static StreamWriter? _writer;
     private static int _pendingLines;
-    public static readonly string Path = System.IO.Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        "Captail", "log.txt");
+    public static readonly string Path = AppDataPaths.LogFile;
 
     static Log() => AppDomain.CurrentDomain.ProcessExit += (_, _) => Close();
 

--- a/src/Captail/ObsPluginDataCache.cs
+++ b/src/Captail/ObsPluginDataCache.cs
@@ -7,18 +7,13 @@ namespace Captail;
 
 internal static class ObsPluginDataCache
 {
-    private const string CacheDirectoryName = "obs-plugin-cache";
-
     public static string Prepare(string packagedDataRoot)
     {
         string sourceRoot = Path.Combine(packagedDataRoot, "obs-plugins");
         if (!Directory.Exists(sourceRoot))
             throw new DirectoryNotFoundException(sourceRoot);
 
-        string cacheRoot = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "Captail",
-            CacheDirectoryName);
+        string cacheRoot = AppDataPaths.ObsPluginCacheDirectory;
         Directory.CreateDirectory(cacheRoot);
 
         string cacheKey = ComputeTreeHash(sourceRoot)[..20].ToLowerInvariant();

--- a/src/Captail/ObsReplayEngine.cs
+++ b/src/Captail/ObsReplayEngine.cs
@@ -138,6 +138,26 @@ public sealed class ObsReplayEngine : IDisposable
             Path.GetFileNameWithoutExtension(foregroundExecutable),
             StringComparison.OrdinalIgnoreCase);
 
+    internal static string? ResolveReplayGameExecutable(
+        bool isAutomaticCapture,
+        bool automaticGameActive,
+        string activeGameExecutable,
+        bool isGameHooked,
+        string hookedExecutable)
+    {
+        if (isAutomaticCapture)
+        {
+            return automaticGameActive &&
+                   !string.IsNullOrWhiteSpace(activeGameExecutable)
+                ? activeGameExecutable
+                : null;
+        }
+
+        return isGameHooked && !string.IsNullOrWhiteSpace(hookedExecutable)
+            ? hookedExecutable
+            : null;
+    }
+
     public bool IsHealthy
     {
         get
@@ -374,6 +394,9 @@ public sealed class ObsReplayEngine : IDisposable
     public ReplaySaveOperation BeginSaveReplay(
         CancellationToken cancellationToken = default)
     {
+        if (IsAutomaticCapture)
+            RefreshCaptureState();
+
         Task<string> completion;
         ulong initialMuxBytes;
         lock (_saveGate)
@@ -399,15 +422,34 @@ public sealed class ObsReplayEngine : IDisposable
             }
         }
 
+        bool isGameHooked = IsGameHooked;
+        string hookedExecutable = isGameHooked
+            ? ReadStringProcedure(
+                ObsNative.obs_source_get_proc_handler(_gameVideoSource),
+                "get_hooked",
+                "executable")
+            : "";
+        string? replayGameExecutable = ResolveReplayGameExecutable(
+            IsAutomaticCapture,
+            _automaticGameActive,
+            _activeGameExecutable,
+            isGameHooked,
+            hookedExecutable);
+        if (IsAutomaticCapture && isGameHooked &&
+            !string.Equals(
+                replayGameExecutable,
+                hookedExecutable,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            Log.Write(
+                "Replay routing ignored inactive Game Capture hook: " +
+                Path.GetFileName(hookedExecutable));
+        }
+
         return new ReplaySaveOperation(
             WaitForSaveCompletionAsync(completion, cancellationToken),
             initialMuxBytes,
-            IsGameHooked
-                ? ReadStringProcedure(
-                    ObsNative.obs_source_get_proc_handler(_gameVideoSource),
-                    "get_hooked",
-                    "executable")
-                : null);
+            replayGameExecutable);
     }
 
     public Task<string> SaveReplayAsync(
@@ -497,10 +539,7 @@ public sealed class ObsReplayEngine : IDisposable
             _obsLibrary = NativeLibrary.Load(obsPath);
         _logBridgeInstalled = ObsLogBridge.Install();
 
-        string configDirectory = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "Captail",
-            "obs");
+        string configDirectory = AppDataPaths.ObsConfigDirectory;
         Directory.CreateDirectory(configDirectory);
         _obsStarted = ObsNative.obs_startup(
             Localization.IsRussian ? "ru-RU" : "en-US",

--- a/src/Captail/ReplayLibrary.cs
+++ b/src/Captail/ReplayLibrary.cs
@@ -26,10 +26,7 @@ public sealed class ReplayLibrary
     public ReplayLibrary(FfmpegAdapter ffmpeg)
     {
         _ffmpeg = ffmpeg;
-        _thumbnailDirectory = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "Captail",
-            "thumbnails");
+        _thumbnailDirectory = AppDataPaths.ThumbnailDirectory;
     }
 
     public async Task<IReadOnlyList<ReplayClip>> GetRecentAsync(

--- a/src/Captail/StorePackageLifecycle.cs
+++ b/src/Captail/StorePackageLifecycle.cs
@@ -1,0 +1,68 @@
+using Windows.ApplicationModel;
+
+namespace Captail;
+
+internal sealed class StorePackageLifecycle : IDisposable
+{
+    private readonly Action<string> _requestShutdown;
+    private PackageCatalog? _catalog;
+    private int _stopping;
+
+    private StorePackageLifecycle(Action<string> requestShutdown)
+    {
+        _requestShutdown = requestShutdown;
+    }
+
+    internal static StorePackageLifecycle? Start(
+        Action<string> requestShutdown)
+    {
+        if (!AppDistribution.IsMicrosoftStore)
+            return null;
+
+        var listener = new StorePackageLifecycle(requestShutdown);
+        try
+        {
+            listener._catalog = PackageCatalog.OpenForCurrentPackage();
+            listener._catalog.PackageUninstalling +=
+                listener.OnPackageUninstalling;
+            listener._catalog.PackageUpdating += listener.OnPackageUpdating;
+            return listener;
+        }
+        catch (Exception exception)
+        {
+            Log.Write(
+                $"Could not monitor Store package lifecycle: {exception.Message}");
+            listener.Dispose();
+            return null;
+        }
+    }
+
+    private void OnPackageUninstalling(
+        PackageCatalog sender,
+        PackageUninstallingEventArgs args) =>
+        SignalStopping("uninstalling");
+
+    private void OnPackageUpdating(
+        PackageCatalog sender,
+        PackageUpdatingEventArgs args) =>
+        SignalStopping("updating");
+
+    private void SignalStopping(string reason)
+    {
+        if (Interlocked.Exchange(ref _stopping, 1) != 0)
+            return;
+
+        Log.Write($"Store package is {reason}; stopping capture.");
+        _requestShutdown(reason);
+    }
+
+    public void Dispose()
+    {
+        PackageCatalog? catalog = Interlocked.Exchange(ref _catalog, null);
+        if (catalog is null)
+            return;
+
+        catalog.PackageUninstalling -= OnPackageUninstalling;
+        catalog.PackageUpdating -= OnPackageUpdating;
+    }
+}

--- a/src/Captail/app.manifest
+++ b/src/Captail/app.manifest
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0"
+          xmlns="urn:schemas-microsoft-com:asm.v1">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">PerMonitorV2,PerMonitor</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/tools/AcquireFfmpegRuntime.ps1
+++ b/tools/AcquireFfmpegRuntime.ps1
@@ -1,13 +1,27 @@
 [CmdletBinding()]
 param(
-    [string]$Destination = ""
+    [string]$Destination = "",
+
+    [ValidateSet("Shared", "Static")]
+    [string]$Flavor = "Shared"
 )
 
 $ErrorActionPreference = "Stop"
 $version = "n7.1.5-12-g1fdbca85aa"
-$archiveName = "ffmpeg-$version-win64-lgpl-shared-7.1.zip"
+$isStatic = $Flavor -eq "Static"
+$archiveName = if ($isStatic) {
+    "ffmpeg-$version-win64-lgpl-7.1.zip"
+}
+else {
+    "ffmpeg-$version-win64-lgpl-shared-7.1.zip"
+}
 $url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-01-13-21/$archiveName"
-$expectedArchiveSha256 = "289ec4ca5a832cb1f2486ee35301d345c5dfaa28018f6177cdbbfbc2ad6f2e33"
+$expectedArchiveSha256 = if ($isStatic) {
+    "bc25a2260a1eaa6fd91d5774a8d8bc425c7d43ae9e8c74297d2d6ebc38e188cb"
+}
+else {
+    "289ec4ca5a832cb1f2486ee35301d345c5dfaa28018f6177cdbbfbc2ad6f2e33"
+}
 $repoRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot ".."))
 $allowedRuntimeRoot = [IO.Path]::GetFullPath((Join-Path $repoRoot "runtime"))
 
@@ -28,7 +42,8 @@ function Get-Sha256Hex([string]$Path) {
 }
 
 if (-not $Destination) {
-    $Destination = Join-Path $allowedRuntimeRoot "ffmpeg"
+    $runtimeName = if ($isStatic) { "ffmpeg-static" } else { "ffmpeg" }
+    $Destination = Join-Path $allowedRuntimeRoot $runtimeName
 }
 
 $Destination = [IO.Path]::GetFullPath($Destination)
@@ -85,6 +100,8 @@ try {
 
     Set-Content -LiteralPath (Join-Path $Destination "VERSION") `
         -Value $version -Encoding UTF8
+    Set-Content -LiteralPath (Join-Path $Destination "FLAVOR") `
+        -Value $Flavor.ToLowerInvariant() -Encoding ascii
     Set-Content -LiteralPath (Join-Path $Destination "SOURCE_URL") `
         -Value $url -Encoding UTF8
     Set-Content -LiteralPath (Join-Path $Destination "SOURCE_SHA256") `
@@ -104,4 +121,4 @@ finally {
     }
 }
 
-Write-Host "FFmpeg runtime $version ready: $Destination"
+Write-Host "FFmpeg runtime $version ($Flavor) ready: $Destination"

--- a/tools/BuildStorePackage.ps1
+++ b/tools/BuildStorePackage.ps1
@@ -36,6 +36,10 @@ $project = Join-Path $repoRoot "src\Captail\Captail.csproj"
 $storeFfmpegRoot = Join-Path $repoRoot "runtime\ffmpeg-store-static"
 $acquireFfmpeg = Join-Path $repoRoot "tools\AcquireFfmpegRuntime.ps1"
 $testFfmpegIsolation = Join-Path $repoRoot "tools\TestStoreFfmpegIsolation.ps1"
+$testNativeDependencies =
+    Join-Path $repoRoot "tools\TestStoreNativeDependencies.ps1"
+$testStoreLifecycle =
+    Join-Path $repoRoot "tools\TestStoreLifecycleIsolation.ps1"
 $manifestTemplate = Join-Path $repoRoot "packaging\msix\AppxManifest.xml.template"
 $iconPath = Join-Path $repoRoot "src\Captail\Assets\Captail.ico"
 
@@ -69,6 +73,7 @@ if (-not $MakeAppxPath -or -not (Test-Path -LiteralPath $MakeAppxPath)) {
 }
 
 Write-Host "Publishing Captail $Version for Microsoft Store..."
+& $testStoreLifecycle
 & $acquireFfmpeg -Destination $storeFfmpegRoot -Flavor Static
 dotnet restore $project `
     --locked-mode `
@@ -183,6 +188,7 @@ if ($identity.Name -ne "faulmit.Captail" -or
     throw "Generated MSIX identity does not match Partner Center."
 }
 & $testFfmpegIsolation -PackageRoot $validationRoot
+& $testNativeDependencies -PackageRoot $validationRoot
 
 Write-Host "Creating Partner Center upload archive..."
 Compress-Archive -LiteralPath $msixPath `

--- a/tools/BuildStorePackage.ps1
+++ b/tools/BuildStorePackage.ps1
@@ -33,6 +33,9 @@ $uploadPath = Join-Path $outputRoot "$packageName.msixupload"
 $uploadZipPath = Join-Path $outputRoot "$packageName.zip"
 $checksumPath = Join-Path $outputRoot "SHA256SUMS.txt"
 $project = Join-Path $repoRoot "src\Captail\Captail.csproj"
+$storeFfmpegRoot = Join-Path $repoRoot "runtime\ffmpeg-store-static"
+$acquireFfmpeg = Join-Path $repoRoot "tools\AcquireFfmpegRuntime.ps1"
+$testFfmpegIsolation = Join-Path $repoRoot "tools\TestStoreFfmpegIsolation.ps1"
 $manifestTemplate = Join-Path $repoRoot "packaging\msix\AppxManifest.xml.template"
 $iconPath = Join-Path $repoRoot "src\Captail\Assets\Captail.ico"
 
@@ -66,6 +69,7 @@ if (-not $MakeAppxPath -or -not (Test-Path -LiteralPath $MakeAppxPath)) {
 }
 
 Write-Host "Publishing Captail $Version for Microsoft Store..."
+& $acquireFfmpeg -Destination $storeFfmpegRoot -Flavor Static
 dotnet restore $project `
     --locked-mode `
     --runtime win-x64 `
@@ -82,6 +86,8 @@ dotnet publish $project `
     -o $packageRoot `
     -p:Version=$Version `
     -p:MicrosoftStoreBuild=true `
+    -p:FfmpegRuntimeRoot=$storeFfmpegRoot `
+    -p:AcquireFfmpegRuntimeOnBuild=false `
     -p:PublishSingleFile=true `
     -p:IncludeNativeLibrariesForSelfExtract=true `
     -p:EnableCompressionInSingleFile=true `
@@ -176,6 +182,7 @@ if ($identity.Name -ne "faulmit.Captail" -or
     $identity.ProcessorArchitecture -ne "x64") {
     throw "Generated MSIX identity does not match Partner Center."
 }
+& $testFfmpegIsolation -PackageRoot $validationRoot
 
 Write-Host "Creating Partner Center upload archive..."
 Compress-Archive -LiteralPath $msixPath `

--- a/tools/TestStoreFfmpegIsolation.ps1
+++ b/tools/TestStoreFfmpegIsolation.ps1
@@ -1,0 +1,74 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$PackageRoot
+)
+
+$ErrorActionPreference = "Stop"
+$packageRoot = [IO.Path]::GetFullPath($PackageRoot)
+$ffmpegRoot = Join-Path $packageRoot "ffmpeg"
+
+if (-not (Test-Path -LiteralPath $ffmpegRoot -PathType Container)) {
+    throw "FFmpeg directory not found: $ffmpegRoot"
+}
+
+$duplicateLibraries = @(
+    Get-ChildItem -LiteralPath $ffmpegRoot -File -Filter *.dll |
+        Where-Object {
+            Test-Path -LiteralPath (Join-Path $packageRoot $_.Name) -PathType Leaf
+        } |
+        Select-Object -ExpandProperty Name
+)
+if ($duplicateLibraries.Count -ne 0) {
+    throw (
+        "Store FFmpeg DLL collision detected: " +
+        ($duplicateLibraries -join ", ") +
+        ". Packaged processes can resolve these names from the package root " +
+        "and fail before FFmpeg starts."
+    )
+}
+
+foreach ($toolName in @("ffmpeg.exe", "ffprobe.exe")) {
+    $toolPath = Join-Path $ffmpegRoot $toolName
+    if (-not (Test-Path -LiteralPath $toolPath -PathType Leaf)) {
+        throw "Store FFmpeg tool not found: $toolPath"
+    }
+
+    $startInfo = [Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $toolPath
+    $startInfo.WorkingDirectory = $ffmpegRoot
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $startInfo.ArgumentList.Add("-version")
+
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    try {
+        if (-not $process.Start()) {
+            throw "Could not start $toolName."
+        }
+        $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+        $stderrTask = $process.StandardError.ReadToEndAsync()
+        if (-not $process.WaitForExit(15000)) {
+            $process.Kill($true)
+            throw "$toolName did not exit within 15 seconds."
+        }
+        $stdout = $stdoutTask.GetAwaiter().GetResult()
+        $stderr = $stderrTask.GetAwaiter().GetResult()
+        if ($process.ExitCode -ne 0) {
+            throw "$toolName failed with exit code $($process.ExitCode): $stderr"
+        }
+        $expectedVersionPrefix =
+            [IO.Path]::GetFileNameWithoutExtension($toolName) + " version"
+        if (($stdout + $stderr) -notmatch [Regex]::Escape($expectedVersionPrefix)) {
+            throw "$toolName returned unexpected version output."
+        }
+    }
+    finally {
+        $process.Dispose()
+    }
+}
+
+Write-Host "PASS: Store FFmpeg is self-contained and starts without package-root DLL collisions."

--- a/tools/TestStoreLifecycleIsolation.ps1
+++ b/tools/TestStoreLifecycleIsolation.ps1
@@ -1,0 +1,58 @@
+[CmdletBinding()]
+param(
+    [string]$ProjectRoot = ""
+)
+
+$ErrorActionPreference = "Stop"
+if (-not $ProjectRoot) {
+    $ProjectRoot = Join-Path $PSScriptRoot "..\src\Captail"
+}
+$ProjectRoot = [IO.Path]::GetFullPath($ProjectRoot)
+
+$pathChecks = [ordered]@{
+    "Config.cs" = "AppDataPaths.ConfigFile"
+    "Log.cs" = "AppDataPaths.LogFile"
+    "ReplayLibrary.cs" = "AppDataPaths.ThumbnailDirectory"
+    "ObsPluginDataCache.cs" = "AppDataPaths.ObsPluginCacheDirectory"
+    "ObsReplayEngine.cs" = "AppDataPaths.ObsConfigDirectory"
+}
+
+foreach ($entry in $pathChecks.GetEnumerator()) {
+    $path = Join-Path $ProjectRoot $entry.Key
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        throw "Store lifecycle source file not found: $path"
+    }
+    $source = Get-Content -LiteralPath $path -Raw
+    if (-not $source.Contains($entry.Value, [StringComparison]::Ordinal)) {
+        throw "$($entry.Key) does not use managed Store data path $($entry.Value)."
+    }
+}
+
+$pathsSource = Join-Path $ProjectRoot "AppDataPaths.cs"
+if (-not (Test-Path -LiteralPath $pathsSource -PathType Leaf)) {
+    throw "AppDataPaths.cs is missing."
+}
+$pathsText = Get-Content -LiteralPath $pathsSource -Raw
+foreach ($required in @(
+    "ApplicationData.Current.LocalFolder.Path",
+    "ApplicationData.Current.LocalCacheFolder.Path")) {
+    if (-not $pathsText.Contains($required, [StringComparison]::Ordinal)) {
+        throw "Store data path resolver is missing: $required"
+    }
+}
+
+$lifecycleSource = Join-Path $ProjectRoot "StorePackageLifecycle.cs"
+if (-not (Test-Path -LiteralPath $lifecycleSource -PathType Leaf)) {
+    throw "StorePackageLifecycle.cs is missing."
+}
+$lifecycleText = Get-Content -LiteralPath $lifecycleSource -Raw
+foreach ($required in @(
+    "PackageCatalog.OpenForCurrentPackage()",
+    "PackageUninstalling",
+    "PackageUpdating")) {
+    if (-not $lifecycleText.Contains($required, [StringComparison]::Ordinal)) {
+        throw "Store package lifecycle listener is missing: $required"
+    }
+}
+
+Write-Host "PASS: Store state is package-managed and update/uninstall events are handled."

--- a/tools/TestStoreNativeDependencies.ps1
+++ b/tools/TestStoreNativeDependencies.ps1
@@ -1,0 +1,95 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$PackageRoot,
+
+    [string]$DumpbinPath = ""
+)
+
+$ErrorActionPreference = "Stop"
+$packageRoot = [IO.Path]::GetFullPath($PackageRoot)
+$manifestPath = Join-Path $packageRoot "AppxManifest.xml"
+$vclibsName = "Microsoft.VCLibs.140.00.UWPDesktop"
+$vclibsPublisher =
+    "CN=Microsoft Corporation, O=Microsoft Corporation, " +
+    "L=Redmond, S=Washington, C=US"
+$minimumVclibsVersion = [Version]"14.0.33728.0"
+
+if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
+    throw "Store manifest not found: $manifestPath"
+}
+
+if (-not $DumpbinPath) {
+    $vswhere = Join-Path ${env:ProgramFiles(x86)} `
+        "Microsoft Visual Studio\Installer\vswhere.exe"
+    if (Test-Path -LiteralPath $vswhere -PathType Leaf) {
+        $DumpbinPath = & $vswhere `
+            -latest `
+            -products '*' `
+            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+            -find 'VC\Tools\MSVC\**\bin\Hostx64\x64\dumpbin.exe' |
+            Select-Object -Last 1
+    }
+}
+if (-not $DumpbinPath -or
+    -not (Test-Path -LiteralPath $DumpbinPath -PathType Leaf)) {
+    throw "dumpbin.exe not found. Install MSVC x64 build tools or pass -DumpbinPath."
+}
+
+$runtimeImports = [Collections.Generic.SortedSet[string]]::new(
+    [StringComparer]::OrdinalIgnoreCase)
+$runtimeUsers = [Collections.Generic.List[string]]::new()
+Get-ChildItem -LiteralPath $packageRoot -Recurse -File |
+    Where-Object { $_.Extension -in ".exe", ".dll" } |
+    ForEach-Object {
+        $relativePath = [IO.Path]::GetRelativePath($packageRoot, $_.FullName)
+        $dependencies = & $DumpbinPath /dependents $_.FullName 2>$null
+        if ($LASTEXITCODE -ne 0) {
+            throw "dumpbin failed for Store binary: $relativePath"
+        }
+
+        $fileUsesRuntime = $false
+        foreach ($line in $dependencies) {
+            if ($line -match `
+                '^\s+(?<name>VCRUNTIME140(?:_1)?|MSVCP140)\.dll\s*$') {
+                [void]$runtimeImports.Add("$($Matches.name).dll")
+                $fileUsesRuntime = $true
+            }
+        }
+        if ($fileUsesRuntime) {
+            $runtimeUsers.Add($relativePath)
+        }
+    }
+
+if ($runtimeImports.Count -eq 0) {
+    Write-Host "PASS: Store native binaries do not import dynamic Visual C++ Runtime libraries."
+    exit 0
+}
+
+[xml]$manifest = Get-Content -LiteralPath $manifestPath -Raw
+$dependency = @($manifest.Package.Dependencies.PackageDependency) |
+    Where-Object { $_.Name -eq $vclibsName } |
+    Select-Object -First 1
+if ($null -eq $dependency) {
+    throw (
+        "Store package imports $($runtimeImports -join ', ') but manifest " +
+        "does not declare $vclibsName. Runtime users: " +
+        ($runtimeUsers -join ", ")
+    )
+}
+if ($dependency.Publisher -ne $vclibsPublisher) {
+    throw "Store VCLibs dependency publisher is invalid: $($dependency.Publisher)"
+}
+
+$declaredVersion = [Version]$dependency.MinVersion
+if ($declaredVersion -lt $minimumVclibsVersion) {
+    throw (
+        "Store VCLibs dependency is too old: $declaredVersion. " +
+        "Required minimum: $minimumVclibsVersion."
+    )
+}
+
+Write-Host (
+    "PASS: Store manifest declares $vclibsName $declaredVersion for " +
+    "$($runtimeUsers.Count) native runtime users."
+)


### PR DESCRIPTION
## Summary

- isolate the Microsoft Store FFmpeg runtime and validate native dependencies
- declare the required Microsoft Visual C++ framework dependency in the MSIX manifest
- move Store state and cache files into package-managed locations
- stop capture during Store package updates and uninstall operations
- make the regular installer stop Captail before uninstall and remove application data
- route automatic-capture replays by the active game instead of a stale Game Capture hook
- add a manual Microsoft Store workflow with build-only, draft, and certification modes

## Why

Store installations could load incompatible FFmpeg DLLs, causing missing-entry-point failures. Store updates and removals also needed package lifecycle handling and package-owned state. Automatic capture could retain an inactive OBS hook and place a CS replay in another application's folder, such as Telegram. Microsoft Store submissions were entirely manual.

## User impact

- Captail version advances to 0.1.8.
- Store FFmpeg startup and native runtime resolution are validated during packaging.
- Store update and uninstall operations request graceful capture shutdown.
- Automatic replay folders follow the game Captail selected for capture.
- Maintainers can build, stage, or submit an MSIX update from GitHub Actions without storing credentials in the repository.

## Validation

- Release build: 0 warnings, 0 errors
- full .NET analyzer build: 0 warnings, 0 errors
- `--qa-capability-model`
- `--qa-replay-routing`
- `--qa-auto-capture-policy`
- Store lifecycle isolation test
- Store FFmpeg isolation test
- Store native dependency test: 26 native runtime users covered by VCLibs
- generated manifest identity: `faulmit.Captail` `0.1.8.0`
- all four GitHub workflows pass actionlint 1.7.12
- `git diff --check`

Local regular-installer uninstall QA was not repeated while the installed Store build was active. The release workflow retains its install, launch, uninstall, process-exit, and AppData cleanup checks.
