### PR TITLE
Remove README gallery note

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,6 @@ Captail is not a streaming application, scene compositor, DRM bypass, or cloud c
 
 ## What does it look like?
 
-Every image in this gallery is captured from a real Captail build. Mockups and concept art are not used as product screenshots. Maintainers can reproduce the baseline with the [screenshot capture workflow](docs/SCREENSHOTS.md).
-
 <p align="center">
   <img src="docs/captail-main.png" alt="Captail main window showing replay status, audio sources, recording format, disk space, and recent replays" width="420">
 </p>


### PR DESCRIPTION
## What changed

Removed the explanatory paragraph above the README screenshot gallery.

## Why

The gallery is self-explanatory and does not need maintainer-facing process text in the main user README.

## Validation

- `git diff --check`
- README image paths remain unchanged
