### PR TITLE
Authenticate FFmpeg metadata requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
 
       - name: Build Release
         shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           dotnet restore ./src/Captail/Captail.csproj --locked-mode
           dotnet build ./Captail.sln -c Release --no-restore `

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,8 @@ jobs:
 
       - name: Build release packages
         shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           dotnet restore ./src/Captail/Captail.csproj --locked-mode
           ./tools/BuildRelease.ps1 `

--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -63,6 +63,8 @@ jobs:
 
       - name: Build Microsoft Store package
         shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           ./tools/BuildStorePackage.ps1 `
             -Version $env:RELEASE_VERSION `

--- a/tools/AcquireFfmpegRuntime.ps1
+++ b/tools/AcquireFfmpegRuntime.ps1
@@ -17,10 +17,16 @@ else {
     "ffmpeg-$version-win64-lgpl-shared-8.1.zip"
 }
 $releaseApiUrl = "https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/tags/latest"
-$release = Invoke-RestMethod -UseBasicParsing -Uri $releaseApiUrl -Headers @{
+$githubHeaders = @{
     Accept = "application/vnd.github+json"
     "User-Agent" = "Captail-build"
 }
+$githubToken = [Environment]::GetEnvironmentVariable("GITHUB_TOKEN")
+if (-not [string]::IsNullOrWhiteSpace($githubToken)) {
+    $githubHeaders.Authorization = "Bearer $githubToken"
+}
+$release = Invoke-RestMethod -UseBasicParsing -Uri $releaseApiUrl `
+    -Headers $githubHeaders
 $asset = $release.assets | Where-Object { $_.name -eq $archiveName } |
     Select-Object -First 1
 if (-not $asset) {


### PR DESCRIPTION
## Summary

- authenticate FFmpeg release metadata requests when `GITHUB_TOKEN` is available
- pass the scoped Actions token from CI, GitHub Release, and Microsoft Store build workflows
- retain unauthenticated fallback for local builds without GitHub credentials

## Cause

The latest `main` build exhausted the shared unauthenticated GitHub API rate limit while resolving the current FFmpeg 8.1 asset.

## Verification

- authenticated FFmpeg runtime acquisition with SHA-256 verification
- Release build: 0 warnings, 0 errors
- `git diff --check`