### PR TITLE
Fix Microsoft Store certification handoff reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,10 @@ jobs:
             -Version ([string]$listing.ReleaseVersion) `
             -ValidateOnly
 
+      - name: Test Microsoft Store release workflow
+        shell: pwsh
+        run: ./tools/TestStoreReleaseWorkflow.ps1
+
       - name: Test sanitized diagnostic log export
         shell: pwsh
         run: ./tools/TestDiagnosticLogExporter.ps1

--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -254,6 +254,16 @@ jobs:
             throw "Partner Center submission commit failed: $LASTEXITCODE"
           }
 
+      - name: Verify certification handoff
+        if: ${{ inputs.mode == 'submit' }}
+        timeout-minutes: 15
+        shell: pwsh
+        run: |
+          & msstore submission poll $env:STORE_PRODUCT_ID
+          if ($LASTEXITCODE -ne 0) {
+            throw "Partner Center rejected or could not finish the submission commit: $LASTEXITCODE"
+          }
+
       - name: Report submission status
         shell: pwsh
         run: |

--- a/docs/MICROSOFT-STORE-RELEASES.md
+++ b/docs/MICROSOFT-STORE-RELEASES.md
@@ -39,7 +39,9 @@ expiration date and update `AZURE_AD_APPLICATION_SECRET` in GitHub.
 7. Keep **Synchronize EN/RU Store text and screenshots** enabled for a normal
    release. Disable it only when intentionally testing package upload without
    changing the Store listing.
-8. Review the workflow summary and Partner Center submission status.
+8. Review the workflow summary and Partner Center submission status. In
+   `submit` mode, the workflow waits for Partner Center to finish the initial
+   submission commit and fails if package processing is rejected or stalls.
 
 The workflow stores the `.msixupload` package for three days. Microsoft Store
 certification and rollout continue in Partner Center after the workflow ends.
@@ -78,6 +80,9 @@ If synchronization fails, the submission stays an uncommitted draft.
 - The package SHA-256 is verified before upload.
 - Store listing metadata and screenshots are validated before Partner Center is
   contacted.
+- A submitted package is not reported as successful while Partner Center still
+  returns `CommitStarted`; the workflow polls the certification handoff and
+  fails on commit errors or timeout.
 - EN/RU listing synchronization is enabled by default and never commits a
   partially updated submission.
 - `build-only` is the default mode.

--- a/tools/TestStoreReleaseWorkflow.ps1
+++ b/tools/TestStoreReleaseWorkflow.ps1
@@ -1,0 +1,37 @@
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$workflowPath = Join-Path $repoRoot ".github\workflows\store-release.yml"
+$workflow = Get-Content -LiteralPath $workflowPath -Raw
+
+function Get-RequiredIndex {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Text
+    )
+
+    $index = $workflow.IndexOf($Text, [StringComparison]::Ordinal)
+    if ($index -lt 0) {
+        throw "Store release workflow is missing required text: $Text"
+    }
+
+    return $index
+}
+
+$uploadIndex = Get-RequiredIndex "- name: Upload package as Partner Center draft"
+$submitIndex = Get-RequiredIndex "- name: Submit draft for certification"
+$handoffIndex = Get-RequiredIndex "- name: Verify certification handoff"
+$pollIndex = Get-RequiredIndex "msstore submission poll"
+$summaryIndex = Get-RequiredIndex "- name: Report submission status"
+
+if ($uploadIndex -ge $submitIndex) {
+    throw "Store package upload must happen before certification submission."
+}
+if ($submitIndex -ge $handoffIndex -or $handoffIndex -ge $summaryIndex) {
+    throw "Certification handoff must be verified after submission and before success is reported."
+}
+if ($pollIndex -lt $handoffIndex -or $pollIndex -ge $summaryIndex) {
+    throw "The Partner Center poll must run inside the certification handoff gate."
+}
+
+Write-Host "Store release workflow waits for Partner Center certification handoff before reporting success."


### PR DESCRIPTION
## Summary
- wait for Partner Center to finish the initial submission commit
- fail Store publishing when package processing is rejected or stalls
- add a CI regression check for workflow step ordering
- document the certification handoff gate

## Root cause
The workflow treated CommitStarted as a successful Store submission. Partner Center later paused package processing, leaving submission 7 in draft while GitHub Actions remained green.

## Validation
- ./tools/TestStoreReleaseWorkflow.ps1
- ./tools/SyncStoreListing.ps1 -Version 0.2.1 -ValidateOnly
- git diff --check