### PR TITLE
Fix Microsoft Store MSIX versioning

### DIFF
--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -7,11 +7,11 @@ on:
         description: Semantic version without the v prefix, for example 0.1.8
         required: true
         type: string
-      package_revision:
-        description: Internal MSIX revision; increase when republishing the same visible version
-        required: true
-        default: 0
-        type: number
+      identity_version:
+        description: Optional internal MSIX identity, for example 0.2.2.0; fourth part must stay 0
+        required: false
+        default: ""
+        type: string
       mode:
         description: Build only, upload a Partner Center draft, or submit for certification
         required: true
@@ -36,7 +36,7 @@ concurrency:
 
 env:
   RELEASE_VERSION: ${{ inputs.version }}
-  STORE_PACKAGE_REVISION: ${{ inputs.package_revision }}
+  STORE_IDENTITY_VERSION: ${{ inputs.identity_version }}
   STORE_OUTPUT: artifacts/store/${{ inputs.version }}
 
 jobs:
@@ -54,9 +54,9 @@ jobs:
           if ($env:RELEASE_VERSION -notmatch '^\d+\.\d+\.\d+$') {
             throw "Invalid semantic version: $env:RELEASE_VERSION"
           }
-          if ($env:STORE_PACKAGE_REVISION -notmatch '^\d+$' -or
-              [int]$env:STORE_PACKAGE_REVISION -gt 65535) {
-            throw "Invalid Store package revision: $env:STORE_PACKAGE_REVISION"
+          if ($env:STORE_IDENTITY_VERSION -and
+              $env:STORE_IDENTITY_VERSION -notmatch '^\d+\.\d+\.\d+\.0$') {
+            throw "Invalid Store identity version: $env:STORE_IDENTITY_VERSION. The fourth part is reserved and must be 0."
           }
           if ($env:RELEASE_MODE -notin @('build-only', 'draft', 'submit')) {
             throw "Invalid release mode: $env:RELEASE_MODE"
@@ -86,16 +86,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          ./tools/BuildStorePackage.ps1 `
-            -Version $env:RELEASE_VERSION `
-            -PackageRevision $env:STORE_PACKAGE_REVISION `
-            -OutputDirectory $env:STORE_OUTPUT
+          $parameters = @{
+            Version = $env:RELEASE_VERSION
+            OutputDirectory = $env:STORE_OUTPUT
+          }
+          if ($env:STORE_IDENTITY_VERSION) {
+            $parameters.IdentityVersion = $env:STORE_IDENTITY_VERSION
+          }
+          ./tools/BuildStorePackage.ps1 @parameters
 
       - name: Verify Store upload artifact
         shell: pwsh
         run: |
-          $upload = Join-Path $env:STORE_OUTPUT `
-            "Captail-$($env:RELEASE_VERSION).$($env:STORE_PACKAGE_REVISION)-x64.msixupload"
+          $uploads = @(Get-ChildItem -LiteralPath $env:STORE_OUTPUT `
+            -Filter '*.msixupload' -File)
+          if ($uploads.Count -ne 1) {
+            throw "Expected one Store upload package, found $($uploads.Count)."
+          }
+          $upload = $uploads[0].FullName
           $checksumFile = Join-Path $env:STORE_OUTPUT 'SHA256SUMS.txt'
           if (-not (Test-Path -LiteralPath $upload)) {
             throw "Store upload package not found: $upload"
@@ -124,7 +132,7 @@ jobs:
         with:
           name: Captail-${{ inputs.version }}-Microsoft-Store
           path: |
-            ${{ env.STORE_OUTPUT }}/Captail-${{ inputs.version }}.${{ inputs.package_revision }}-x64.msixupload
+            ${{ env.STORE_OUTPUT }}/*.msixupload
             ${{ env.STORE_OUTPUT }}/SHA256SUMS.txt
           if-no-files-found: error
           retention-days: 3
@@ -278,12 +286,18 @@ jobs:
           else {
             'submitted to Microsoft certification'
           }
+          $identityVersion = if ($env:STORE_IDENTITY_VERSION) {
+            $env:STORE_IDENTITY_VERSION
+          }
+          else {
+            "$env:RELEASE_VERSION.0"
+          }
           @"
           ## Captail $env:RELEASE_VERSION
 
           Package $action.
 
-          MSIX identity version: ``$env:RELEASE_VERSION.$env:STORE_PACKAGE_REVISION``
+          MSIX identity version: ``$identityVersion``
 
           Store listing synchronization: ``$env:UPDATE_STORE_LISTING``
 

--- a/docs/MICROSOFT-STORE-RELEASES.md
+++ b/docs/MICROSOFT-STORE-RELEASES.md
@@ -27,11 +27,11 @@ expiration date and update `AZURE_AD_APPLICATION_SECRET` in GitHub.
 1. Merge the release-ready code into `main`.
 2. Open **Actions** and select **Microsoft Store release**.
 3. Select **Run workflow** from `main`.
-4. Enter the three-part version, for example `0.2.0`.
-5. Keep package revision `0` for a new visible version. Increase it when
-   republishing the same visible version, for example `0.2.1` revision `1`
-   produces MSIX identity version `0.2.1.1` while Captail still displays
-   `0.2.1`.
+4. Enter the three-part Captail version, for example `0.2.1`.
+5. Leave **Internal MSIX identity** empty for a normal release. The workflow
+   then uses `0.2.1.0`. For a Store-only republish of the same visible version,
+   enter a higher four-part identity ending in `.0`, for example `0.2.2.0`.
+   Microsoft reserves the fourth field and rejects packages such as `0.2.1.1`.
 6. Select one mode:
    - `build-only`: build and validate the package without contacting Partner Center.
    - `draft`: upload the package but leave the submission as a draft.
@@ -83,6 +83,8 @@ If synchronization fails, the submission stays an uncommitted draft.
 - A submitted package is not reported as successful while Partner Center still
   returns `CommitStarted`; the workflow polls the certification handoff and
   fails on commit errors or timeout.
+- Store package identity always ends in `.0`; CI rejects workflows that expose
+  Microsoft's reserved fourth version field as a revision counter.
 - EN/RU listing synchronization is enabled by default and never commits a
   partially updated submission.
 - `build-only` is the default mode.

--- a/tools/BuildStorePackage.ps1
+++ b/tools/BuildStorePackage.ps1
@@ -4,8 +4,8 @@ param(
     [ValidatePattern('^\d+\.\d+\.\d+$')]
     [string]$Version,
 
-    [ValidateRange(0, 65535)]
-    [int]$PackageRevision = 0,
+    [ValidatePattern('^\d+\.\d+\.\d+\.0$')]
+    [string]$IdentityVersion = "",
 
     [string]$OutputDirectory = "",
 
@@ -25,7 +25,7 @@ if (-not $outputRoot.StartsWith($repoPrefix, [StringComparison]::OrdinalIgnoreCa
     throw "Store output must stay inside repository: $outputRoot"
 }
 
-$packageVersion = "$Version.$PackageRevision"
+$packageVersion = if ($IdentityVersion) { $IdentityVersion } else { "$Version.0" }
 $packageName = "Captail-$packageVersion-x64"
 $stagingRoot = Join-Path $outputRoot "staging"
 $dotnetArtifacts = Join-Path $stagingRoot "dotnet"

--- a/tools/TestStoreReleaseWorkflow.ps1
+++ b/tools/TestStoreReleaseWorkflow.ps1
@@ -4,6 +4,19 @@ $repoRoot = Split-Path -Parent $PSScriptRoot
 $workflowPath = Join-Path $repoRoot ".github\workflows\store-release.yml"
 $workflow = Get-Content -LiteralPath $workflowPath -Raw
 
+if ($workflow -match '(?m)^\s*package_revision:') {
+    throw "Store workflow must not expose the reserved MSIX revision field."
+}
+if ($workflow -match 'STORE_PACKAGE_REVISION|PackageRevision') {
+    throw "Store workflow must keep the reserved MSIX revision field at zero."
+}
+if ($workflow -notmatch "STORE_IDENTITY_VERSION -notmatch '\^\\d\+\\\.\\d\+\\\.\\d\+\\\.0\$'") {
+    throw "Store workflow must reject an MSIX identity whose fourth part is not zero."
+}
+if ($workflow -notmatch [regex]::Escape('MSIX identity version: ``$identityVersion``')) {
+    throw "Store workflow must report the validated MSIX identity version."
+}
+
 function Get-RequiredIndex {
     param(
         [Parameter(Mandatory)]


### PR DESCRIPTION
## Summary
- keep Microsoft-reserved MSIX revision field at zero
- allow separate internal Store identity for same visible Captail version
- verify Partner Center certification handoff and document Store-only republish flow

## Validation
- ./tools/TestStoreReleaseWorkflow.ps1`n- ./tools/SyncStoreListing.ps1 -Version 0.2.1 -ValidateOnly`n- PowerShell parser validation
- invalid 