### PR TITLE
Fix Store taskbar icon resource indexing

### DIFF
--- a/tools/BuildStorePackage.ps1
+++ b/tools/BuildStorePackage.ps1
@@ -9,7 +9,9 @@ param(
 
     [string]$OutputDirectory = "",
 
-    [string]$MakeAppxPath = ""
+    [string]$MakeAppxPath = "",
+
+    [string]$MakePriPath = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -75,6 +77,12 @@ if (-not $MakeAppxPath) {
 }
 if (-not $MakeAppxPath -or -not (Test-Path -LiteralPath $MakeAppxPath)) {
     throw "MakeAppx.exe not found. Install Windows SDK or pass -MakeAppxPath."
+}
+if (-not $MakePriPath) {
+    $MakePriPath = Join-Path (Split-Path -Parent $MakeAppxPath) "makepri.exe"
+}
+if (-not (Test-Path -LiteralPath $MakePriPath -PathType Leaf)) {
+    throw "MakePri.exe not found. Install Windows SDK or pass -MakePriPath."
 }
 
 Write-Host "Publishing Captail $Version for Microsoft Store..."
@@ -246,6 +254,27 @@ $manifestPath = Join-Path $packageRoot "AppxManifest.xml"
     $manifestPath,
     $manifest,
     [Text.UTF8Encoding]::new($false))
+
+$priConfigPath = Join-Path $packageRoot "priconfig.xml"
+$resourceIndexPath = Join-Path $packageRoot "resources.pri"
+Write-Host "Generating package resource index..."
+& $MakePriPath createconfig /cf $priConfigPath /dq en-US /o
+if ($LASTEXITCODE -ne 0) {
+    throw "MakePri createconfig failed with exit code $LASTEXITCODE."
+}
+& $MakePriPath new `
+    /pr $packageRoot `
+    /cf $priConfigPath `
+    /in "faulmit.Captail" `
+    /of $resourceIndexPath `
+    /o
+if ($LASTEXITCODE -ne 0) {
+    throw "MakePri new failed with exit code $LASTEXITCODE."
+}
+if (-not (Test-Path -LiteralPath $resourceIndexPath -PathType Leaf)) {
+    throw "MakePri did not create resources.pri."
+}
+Remove-Item -LiteralPath $priConfigPath -Force
 
 Write-Host "Creating MSIX..."
 & $MakeAppxPath pack /d $packageRoot /p $msixPath /o

--- a/tools/TestStoreIconAssets.ps1
+++ b/tools/TestStoreIconAssets.ps1
@@ -10,6 +10,14 @@ if (-not (Test-Path -LiteralPath $resolvedPackageRoot -PathType Container)) {
     throw "Store package root not found: $resolvedPackageRoot"
 }
 
+$resourceIndex = Join-Path $resolvedPackageRoot "resources.pri"
+if (-not (Test-Path -LiteralPath $resourceIndex -PathType Leaf)) {
+    throw "Store package resource index not found: $resourceIndex"
+}
+if ((Get-Item -LiteralPath $resourceIndex).Length -le 0) {
+    throw "Store package resource index is empty: $resourceIndex"
+}
+
 $assetsDirectory = Join-Path $resolvedPackageRoot "Assets"
 $baseLogo = Join-Path $assetsDirectory "Square44x44Logo.png"
 if (-not (Test-Path -LiteralPath $baseLogo -PathType Leaf)) {


### PR DESCRIPTION
## Summary
- generate esources.pri while building Microsoft Store packages
- fail Store icon validation when package resource index is missing or empty
- keep existing Store listing metadata unchanged

## Verification
- built and unpacked MSIX identity 