### PR TITLE
feat: add advanced process audio backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@ artifacts/
 runtime/
 src/**/bin/
 src/**/obj/
-native/**/build/
+native/**/build*/
+tools/**/bin/
+tools/**/obj/
 
 # IDE and user state
 .vs/

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -11,6 +11,14 @@ Captail dynamically uses and may redistribute selected components from OBS Studi
 
 `tools/AcquireObsRuntime.ps1` prepares the runtime. Distributions contain only components required for libobs, Replay Buffer, Windows capture, WASAPI audio, and supported hardware encoders.
 
+Captail's `native/ProcessAudio` module narrowly adapts the process-loopback
+activation, audio format, silent-buffer, timestamp, and packet-delivery portions
+of OBS Studio 32.1.2 `plugins/win-wasapi/win-wasapi.cpp`. Window matching,
+device capture, OBS UI properties, and other unrelated `win-wasapi`
+functionality are not copied. `tools/AcquireObsPluginSdk.ps1` downloads the
+pinned OBS 32.1.2 source archive with SHA-256 verification and extracts the
+public libobs headers used to compile the module.
+
 ## FFmpeg
 
 - Project: https://ffmpeg.org/

--- a/native/ProcessAudio/CMakeLists.txt
+++ b/native/ProcessAudio/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.20)
+project(CaptailProcessAudio LANGUAGES CXX)
+
+if(NOT DEFINED OBS_INCLUDE_DIR OR NOT EXISTS "${OBS_INCLUDE_DIR}/obs-module.h")
+  message(FATAL_ERROR "OBS_INCLUDE_DIR must point to the pinned libobs public headers")
+endif()
+
+add_library(CaptailProcessAudio MODULE CaptailProcessAudio.cpp)
+
+set(OBS_IMPORT_LIBRARY "${CMAKE_CURRENT_BINARY_DIR}/obs.lib")
+add_custom_command(
+  OUTPUT "${OBS_IMPORT_LIBRARY}"
+  COMMAND
+    "${CMAKE_AR}" /nologo
+    "/def:${CMAKE_CURRENT_SOURCE_DIR}/Obs.def"
+    /machine:x64
+    "/out:${OBS_IMPORT_LIBRARY}"
+  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/Obs.def"
+  VERBATIM)
+add_custom_target(CaptailObsImportLibrary DEPENDS "${OBS_IMPORT_LIBRARY}")
+add_dependencies(CaptailProcessAudio CaptailObsImportLibrary)
+
+target_compile_features(CaptailProcessAudio PRIVATE cxx_std_20)
+target_compile_definitions(
+  CaptailProcessAudio
+  PRIVATE WIN32_LEAN_AND_MEAN NOMINMAX UNICODE _UNICODE _WIN32_WINNT=0x0A00)
+target_include_directories(CaptailProcessAudio SYSTEM PRIVATE "${OBS_INCLUDE_DIR}")
+target_link_libraries(CaptailProcessAudio PRIVATE "${OBS_IMPORT_LIBRARY}" avrt ole32)
+
+if(MSVC)
+  target_compile_options(CaptailProcessAudio PRIVATE /W4 /permissive- /EHsc)
+  set_property(
+    TARGET CaptailProcessAudio
+    PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+endif()
+
+set_target_properties(
+  CaptailProcessAudio
+  PROPERTIES OUTPUT_NAME "captail-process-audio" PREFIX "")

--- a/native/ProcessAudio/CaptailProcessAudio.cpp
+++ b/native/ProcessAudio/CaptailProcessAudio.cpp
@@ -1,0 +1,557 @@
+/******************************************************************************
+    Captail PID-aware process audio source.
+
+    Process-loopback activation, format construction, silent-buffer handling,
+    timestamps, and OBS audio delivery are narrowly adapted from OBS Studio
+    32.1.2 plugins/win-wasapi/win-wasapi.cpp.
+
+    OBS Studio copyright (C) Hugh Bailey and contributors.
+    Captail adaptation copyright (C) Captail contributors.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+******************************************************************************/
+
+#include <obs-module.h>
+
+#include <Windows.h>
+#include <audioclient.h>
+#include <audioclientactivationparams.h>
+#include <avrt.h>
+#include <ksmedia.h>
+#include <mmdeviceapi.h>
+#include <wrl/client.h>
+#include <wrl/implements.h>
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+using Microsoft::WRL::ComPtr;
+
+namespace {
+
+constexpr const char *SourceId = "captail_process_audio_capture";
+constexpr const char *TargetPidSetting = "target_pid";
+constexpr const char *TargetCreationTimeSetting = "target_creation_time";
+constexpr REFERENCE_TIME BufferTime100Ns = 5 * 10000000LL;
+constexpr DWORD RetryDelayMilliseconds = 1000;
+
+enum class SourceState : long long {
+    Idle,
+    Starting,
+    Capturing,
+    TargetExited,
+    ActivationFailed,
+    CaptureFailed,
+    Stopped,
+};
+
+using ActivateAudioInterfaceAsyncFn = HRESULT(STDAPICALLTYPE *)(
+    LPCWSTR,
+    REFIID,
+    PROPVARIANT *,
+    IActivateAudioInterfaceCompletionHandler *,
+    IActivateAudioInterfaceAsyncOperation **);
+
+class ActivationHandler final
+    : public Microsoft::WRL::RuntimeClass<
+          Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::ClassicCom>,
+          Microsoft::WRL::FtmBase,
+          IActivateAudioInterfaceCompletionHandler> {
+public:
+    ActivationHandler() : event_(CreateEventW(nullptr, FALSE, FALSE, nullptr)) {}
+
+    ~ActivationHandler() override
+    {
+        if (event_)
+            CloseHandle(event_);
+    }
+
+    HRESULT WaitForResult(IAudioClient **client)
+    {
+        if (!event_)
+            return HRESULT_FROM_WIN32(GetLastError());
+        WaitForSingleObject(event_, INFINITE);
+        if (SUCCEEDED(result_) && activated_)
+            return activated_.CopyTo(client);
+        return result_;
+    }
+
+    HRESULT STDMETHODCALLTYPE ActivateCompleted(
+        IActivateAudioInterfaceAsyncOperation *operation) override
+    {
+        HRESULT activationResult = E_FAIL;
+        ComPtr<IUnknown> activated;
+        HRESULT result = operation->GetActivateResult(
+            &activationResult,
+            activated.GetAddressOf());
+        result_ = SUCCEEDED(result) ? activationResult : result;
+        activated_ = std::move(activated);
+        if (event_)
+            SetEvent(event_);
+        return S_OK;
+    }
+
+private:
+    HANDLE event_ = nullptr;
+    HRESULT result_ = E_PENDING;
+    ComPtr<IUnknown> activated_;
+};
+
+DWORD SpeakerChannelMask(speaker_layout speakers)
+{
+    switch (speakers) {
+    case SPEAKERS_MONO:
+        return KSAUDIO_SPEAKER_MONO;
+    case SPEAKERS_STEREO:
+        return KSAUDIO_SPEAKER_STEREO;
+    case SPEAKERS_2POINT1:
+        return KSAUDIO_SPEAKER_2POINT1;
+    case SPEAKERS_4POINT0:
+        return KSAUDIO_SPEAKER_SURROUND;
+    case SPEAKERS_4POINT1:
+        return KSAUDIO_SPEAKER_SURROUND | SPEAKER_LOW_FREQUENCY;
+    case SPEAKERS_5POINT1:
+        return KSAUDIO_SPEAKER_5POINT1_SURROUND;
+    case SPEAKERS_7POINT1:
+        return KSAUDIO_SPEAKER_7POINT1_SURROUND;
+    default:
+        return 0;
+    }
+}
+
+uint64_t FileTimeValue(const FILETIME &time)
+{
+    ULARGE_INTEGER value{};
+    value.LowPart = time.dwLowDateTime;
+    value.HighPart = time.dwHighDateTime;
+    return value.QuadPart;
+}
+
+class ProcessAudioSource {
+public:
+    ProcessAudioSource(obs_data_t *settings, obs_source_t *source)
+        : source_(source)
+    {
+        const long long processId = obs_data_get_int(settings, TargetPidSetting);
+        const long long creationTime =
+            obs_data_get_int(settings, TargetCreationTimeSetting);
+        if (!source_ || processId <= 0 || processId > MAXDWORD || creationTime <= 0)
+            throw E_INVALIDARG;
+
+        processId_ = static_cast<DWORD>(processId);
+        creationTime_ = static_cast<uint64_t>(creationTime);
+        try {
+            stopEvent_ = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+            if (!stopEvent_)
+                throw HRESULT_FROM_WIN32(GetLastError());
+
+            process_ = OpenProcess(
+                PROCESS_QUERY_LIMITED_INFORMATION | SYNCHRONIZE,
+                FALSE,
+                processId_);
+            if (!process_)
+                throw HRESULT_FROM_WIN32(GetLastError());
+            if (!IdentityMatches())
+                throw HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
+        } catch (...) {
+            if (process_)
+                CloseHandle(process_);
+            if (stopEvent_)
+                CloseHandle(stopEvent_);
+            process_ = nullptr;
+            stopEvent_ = nullptr;
+            throw;
+        }
+    }
+
+    ~ProcessAudioSource()
+    {
+        Stop();
+        if (process_)
+            CloseHandle(process_);
+        if (stopEvent_)
+            CloseHandle(stopEvent_);
+    }
+
+    void Start()
+    {
+        std::lock_guard lock(workerMutex_);
+        if (worker_.joinable())
+            return;
+        ResetEvent(stopEvent_);
+        state_ = SourceState::Starting;
+        error_ = S_OK;
+        worker_ = std::thread(&ProcessAudioSource::Run, this);
+    }
+
+    void Stop()
+    {
+        std::thread worker;
+        {
+            std::lock_guard lock(workerMutex_);
+            if (!worker_.joinable()) {
+                state_ = SourceState::Stopped;
+                return;
+            }
+            SetEvent(stopEvent_);
+            worker = std::move(worker_);
+        }
+        worker.join();
+        state_ = SourceState::Stopped;
+    }
+
+    SourceState State() const { return state_.load(); }
+    HRESULT Error() const { return error_.load(); }
+
+private:
+    enum class CaptureResult {
+        Stopped,
+        TargetExited,
+        Failed,
+    };
+
+    bool IdentityMatches() const
+    {
+        if (!process_ || WaitForSingleObject(process_, 0) == WAIT_OBJECT_0)
+            return false;
+        FILETIME creation{}, exit{}, kernel{}, user{};
+        return GetProcessTimes(process_, &creation, &exit, &kernel, &user) &&
+               FileTimeValue(creation) == creationTime_;
+    }
+
+    void Run()
+    {
+        const HRESULT comResult = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+        const bool comInitialized = SUCCEEDED(comResult);
+        DWORD taskIndex = 0;
+        HANDLE mmcss = AvSetMmThreadCharacteristicsW(L"Audio", &taskIndex);
+
+        while (WaitForSingleObject(stopEvent_, 0) != WAIT_OBJECT_0) {
+            if (!IdentityMatches()) {
+                state_ = SourceState::TargetExited;
+                break;
+            }
+
+            bool activationFailed = false;
+            HRESULT failure = S_OK;
+            CaptureResult result = CaptureOnce(activationFailed, failure);
+            if (result == CaptureResult::Stopped)
+                break;
+            if (result == CaptureResult::TargetExited) {
+                state_ = SourceState::TargetExited;
+                break;
+            }
+
+            state_ = activationFailed
+                ? SourceState::ActivationFailed
+                : SourceState::CaptureFailed;
+            error_ = failure;
+            HANDLE retryHandles[] = {stopEvent_, process_};
+            DWORD wait = WaitForMultipleObjects(
+                2,
+                retryHandles,
+                FALSE,
+                RetryDelayMilliseconds);
+            if (wait == WAIT_OBJECT_0)
+                break;
+            if (wait == WAIT_OBJECT_0 + 1) {
+                state_ = SourceState::TargetExited;
+                break;
+            }
+        }
+
+        if (mmcss)
+            AvRevertMmThreadCharacteristics(mmcss);
+        if (comInitialized)
+            CoUninitialize();
+    }
+
+    CaptureResult CaptureOnce(bool &activationFailed, HRESULT &failure)
+    {
+        activationFailed = true;
+        HMODULE mmdevapi = GetModuleHandleW(L"Mmdevapi.dll");
+        if (!mmdevapi)
+            mmdevapi = LoadLibraryW(L"Mmdevapi.dll");
+        if (!mmdevapi) {
+            failure = HRESULT_FROM_WIN32(GetLastError());
+            return CaptureResult::Failed;
+        }
+
+        auto activate = reinterpret_cast<ActivateAudioInterfaceAsyncFn>(
+            GetProcAddress(mmdevapi, "ActivateAudioInterfaceAsync"));
+        if (!activate) {
+            failure = HRESULT_FROM_WIN32(GetLastError());
+            return CaptureResult::Failed;
+        }
+
+        obs_audio_info audioInfo{};
+        if (!obs_get_audio_info(&audioInfo)) {
+            failure = E_FAIL;
+            return CaptureResult::Failed;
+        }
+
+        WAVEFORMATEXTENSIBLE wave{};
+        const WORD channels = static_cast<WORD>(get_audio_channels(audioInfo.speakers));
+        if (channels == 0) {
+            failure = E_INVALIDARG;
+            return CaptureResult::Failed;
+        }
+        constexpr WORD bitsPerSample = 32;
+        const WORD blockAlign = channels * bitsPerSample / 8;
+        wave.Format.wFormatTag = WAVE_FORMAT_EXTENSIBLE;
+        wave.Format.nChannels = channels;
+        wave.Format.nSamplesPerSec = audioInfo.samples_per_sec;
+        wave.Format.nAvgBytesPerSec = audioInfo.samples_per_sec * blockAlign;
+        wave.Format.nBlockAlign = blockAlign;
+        wave.Format.wBitsPerSample = bitsPerSample;
+        wave.Format.cbSize = sizeof(wave) - sizeof(wave.Format);
+        wave.Samples.wValidBitsPerSample = bitsPerSample;
+        wave.dwChannelMask = SpeakerChannelMask(audioInfo.speakers);
+        wave.SubFormat = KSDATAFORMAT_SUBTYPE_IEEE_FLOAT;
+
+        AUDIOCLIENT_ACTIVATION_PARAMS activationParams{};
+        activationParams.ActivationType = AUDIOCLIENT_ACTIVATION_TYPE_PROCESS_LOOPBACK;
+        activationParams.ProcessLoopbackParams.TargetProcessId = processId_;
+        activationParams.ProcessLoopbackParams.ProcessLoopbackMode =
+            PROCESS_LOOPBACK_MODE_INCLUDE_TARGET_PROCESS_TREE;
+
+        PROPVARIANT parameters{};
+        parameters.vt = VT_BLOB;
+        parameters.blob.cbSize = sizeof(activationParams);
+        parameters.blob.pBlobData = reinterpret_cast<BYTE *>(&activationParams);
+
+        ComPtr<ActivationHandler> handler = Microsoft::WRL::Make<ActivationHandler>();
+        if (!handler) {
+            failure = E_OUTOFMEMORY;
+            return CaptureResult::Failed;
+        }
+        ComPtr<IActivateAudioInterfaceAsyncOperation> operation;
+        HRESULT result = activate(
+            VIRTUAL_AUDIO_DEVICE_PROCESS_LOOPBACK,
+            __uuidof(IAudioClient),
+            &parameters,
+            handler.Get(),
+            operation.GetAddressOf());
+        if (FAILED(result)) {
+            failure = result;
+            return CaptureResult::Failed;
+        }
+
+        ComPtr<IAudioClient> client;
+        result = handler->WaitForResult(client.GetAddressOf());
+        if (FAILED(result)) {
+            failure = result;
+            return CaptureResult::Failed;
+        }
+        if (!IdentityMatches())
+            return CaptureResult::TargetExited;
+
+        result = client->Initialize(
+            AUDCLNT_SHAREMODE_SHARED,
+            AUDCLNT_STREAMFLAGS_EVENTCALLBACK | AUDCLNT_STREAMFLAGS_LOOPBACK,
+            BufferTime100Ns,
+            0,
+            &wave.Format,
+            nullptr);
+        if (FAILED(result)) {
+            failure = result;
+            return CaptureResult::Failed;
+        }
+
+        HANDLE sampleEvent = CreateEventW(nullptr, FALSE, FALSE, nullptr);
+        if (!sampleEvent) {
+            failure = HRESULT_FROM_WIN32(GetLastError());
+            return CaptureResult::Failed;
+        }
+
+        ComPtr<IAudioCaptureClient> capture;
+        result = client->GetService(IID_PPV_ARGS(capture.GetAddressOf()));
+        if (SUCCEEDED(result))
+            result = client->SetEventHandle(sampleEvent);
+        if (SUCCEEDED(result))
+            result = client->Start();
+        if (FAILED(result)) {
+            CloseHandle(sampleEvent);
+            failure = result;
+            return CaptureResult::Failed;
+        }
+
+        activationFailed = false;
+        state_ = SourceState::Capturing;
+        error_ = S_OK;
+        HANDLE handles[] = {stopEvent_, process_, sampleEvent};
+        CaptureResult captureResult = CaptureResult::Failed;
+        while (true) {
+            DWORD wait = WaitForMultipleObjects(3, handles, FALSE, INFINITE);
+            if (wait == WAIT_OBJECT_0) {
+                captureResult = CaptureResult::Stopped;
+                break;
+            }
+            if (wait == WAIT_OBJECT_0 + 1) {
+                captureResult = CaptureResult::TargetExited;
+                break;
+            }
+            if (wait != WAIT_OBJECT_0 + 2) {
+                failure = HRESULT_FROM_WIN32(GetLastError());
+                break;
+            }
+            if (!OutputPackets(capture.Get(), audioInfo)) {
+                failure = lastCaptureError_;
+                break;
+            }
+        }
+
+        client->Stop();
+        CloseHandle(sampleEvent);
+        return captureResult;
+    }
+
+    bool OutputPackets(IAudioCaptureClient *capture, const obs_audio_info &audioInfo)
+    {
+        UINT32 packetFrames = 0;
+        HRESULT result = capture->GetNextPacketSize(&packetFrames);
+        while (SUCCEEDED(result) && packetFrames > 0) {
+            BYTE *buffer = nullptr;
+            UINT32 frames = 0;
+            DWORD flags = 0;
+            UINT64 devicePosition = 0;
+            UINT64 timestamp = 0;
+            result = capture->GetBuffer(
+                &buffer,
+                &frames,
+                &flags,
+                &devicePosition,
+                &timestamp);
+            if (FAILED(result))
+                break;
+
+            if ((flags & AUDCLNT_BUFFERFLAGS_SILENT) != 0) {
+                size_t required = static_cast<size_t>(
+                    get_audio_channels(audioInfo.speakers)) * frames * sizeof(float);
+                if (silence_.size() < required)
+                    silence_.resize(required, 0);
+                buffer = silence_.data();
+            }
+
+            obs_source_audio audio{};
+            audio.data[0] = buffer;
+            audio.frames = frames;
+            audio.speakers = audioInfo.speakers;
+            audio.samples_per_sec = audioInfo.samples_per_sec;
+            audio.format = AUDIO_FORMAT_FLOAT;
+            audio.timestamp = timestamp * 100;
+            obs_source_output_audio(source_, &audio);
+            capture->ReleaseBuffer(frames);
+
+            result = capture->GetNextPacketSize(&packetFrames);
+        }
+
+        if (FAILED(result)) {
+            lastCaptureError_ = result;
+            return false;
+        }
+        return true;
+    }
+
+    obs_source_t *source_ = nullptr;
+    DWORD processId_ = 0;
+    uint64_t creationTime_ = 0;
+    HANDLE process_ = nullptr;
+    HANDLE stopEvent_ = nullptr;
+    std::atomic<SourceState> state_{SourceState::Idle};
+    std::atomic<HRESULT> error_{S_OK};
+    HRESULT lastCaptureError_ = S_OK;
+    std::mutex workerMutex_;
+    std::thread worker_;
+    std::vector<BYTE> silence_;
+};
+
+const char *GetSourceName(void *)
+{
+    return "Captail process audio";
+}
+
+void GetStatus(void *data, calldata_t *callData)
+{
+    auto *source = static_cast<ProcessAudioSource *>(data);
+    if (!source)
+        return;
+    const long long state = static_cast<long long>(source->State());
+    const long long errorCode = source->Error();
+    calldata_set_data(callData, "state", &state, sizeof(state));
+    calldata_set_data(
+        callData,
+        "error_code",
+        &errorCode,
+        sizeof(errorCode));
+}
+
+void *CreateSource(obs_data_t *settings, obs_source_t *source)
+{
+    try {
+        auto *processSource = new ProcessAudioSource(settings, source);
+        proc_handler_t *handler = obs_source_get_proc_handler(source);
+        if (handler) {
+            proc_handler_add(
+                handler,
+                "void get_status(out int state, out int error_code)",
+                GetStatus,
+                processSource);
+        }
+        return processSource;
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+void DestroySource(void *data)
+{
+    delete static_cast<ProcessAudioSource *>(data);
+}
+
+void ActivateSource(void *data)
+{
+    auto *source = static_cast<ProcessAudioSource *>(data);
+    if (source)
+        source->Start();
+}
+
+void DeactivateSource(void *data)
+{
+    auto *source = static_cast<ProcessAudioSource *>(data);
+    if (source)
+        source->Stop();
+}
+
+} // namespace
+
+OBS_DECLARE_MODULE()
+
+MODULE_EXPORT const char *obs_module_description(void)
+{
+    return "Captail PID-aware Windows process audio source";
+}
+
+bool obs_module_load(void)
+{
+    obs_source_info info{};
+    info.id = SourceId;
+    info.type = OBS_SOURCE_TYPE_INPUT;
+    info.output_flags = OBS_SOURCE_AUDIO |
+                        OBS_SOURCE_DO_NOT_DUPLICATE |
+                        OBS_SOURCE_DO_NOT_SELF_MONITOR;
+    info.get_name = GetSourceName;
+    info.create = CreateSource;
+    info.destroy = DestroySource;
+    info.activate = ActivateSource;
+    info.deactivate = DeactivateSource;
+    info.icon_type = OBS_ICON_TYPE_PROCESS_AUDIO_OUTPUT;
+    obs_register_source(&info);
+    return true;
+}

--- a/native/ProcessAudio/Obs.def
+++ b/native/ProcessAudio/Obs.def
@@ -1,0 +1,9 @@
+LIBRARY obs.dll
+EXPORTS
+    calldata_set_data
+    obs_data_get_int
+    obs_get_audio_info
+    obs_register_source_s
+    obs_source_get_proc_handler
+    obs_source_output_audio
+    proc_handler_add

--- a/native/ProcessAudio/README.md
+++ b/native/ProcessAudio/README.md
@@ -1,0 +1,22 @@
+# Captail process audio source
+
+This module implements the private `captail_process_audio_capture` libobs input
+source used by Captail's PID-aware audio foundation. It accepts only a target
+process ID and the target's Windows process creation time. Discovery, process
+tree selection, routing policy, and persistence remain outside the module.
+
+The process-loopback activation, libobs audio format construction, silent
+buffer handling, timestamps, and packet delivery are narrowly adapted from:
+
+- OBS Studio 32.1.2
+- `plugins/win-wasapi/win-wasapi.cpp`
+- https://github.com/obsproject/obs-studio/tree/32.1.2
+
+Window matching, device capture, default-device notification, UI properties,
+localization, rerouting, and executable-name logging were intentionally not
+copied. OBS Studio and this adaptation are licensed under GNU GPL version 2 or
+later. Captail's repository `LICENSE` contains the applicable GPL text.
+
+The build generates a minimal `obs.lib` from `Obs.def`, containing only the
+libobs exports used by this source. It links against Captail's existing bundled
+`obs.dll`; libobs and `win-wasapi` are not rebuilt or replaced.

--- a/src/Captail/App.xaml.cs
+++ b/src/Captail/App.xaml.cs
@@ -7,6 +7,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Threading;
+using Captail.Interop;
 using H.NotifyIcon;
 
 namespace Captail;
@@ -50,6 +51,9 @@ public partial class App : Application
     private readonly SemaphoreSlim _pipelineGate = new(1, 1);
     private readonly SingleThreadTaskScheduler _obsTaskScheduler =
         new("Captail OBS");
+    private ProcessAudioMonitor? _processAudioMonitor;
+    private AdvancedProcessAudioAvailability _processAudioAvailability =
+        AdvancedProcessAudioAvailability.SourceUnavailable;
     private volatile bool _replayRunning;
     private string? _captureDescription;
     private int _exiting;
@@ -60,6 +64,8 @@ public partial class App : Application
 #endif
 
     private bool IsReplayRunning => _replayRunning;
+    internal AdvancedProcessAudioAvailability ProcessAudioAvailability =>
+        _processAudioAvailability;
 
     protected override async void OnStartup(StartupEventArgs e)
     {
@@ -898,9 +904,24 @@ public partial class App : Application
                 0,
                 0,
                 10_000);
+            int recordingSeconds = ParseQaInt(
+                args,
+                "--qa-record-seconds=",
+                4,
+                1,
+                30);
             bool audioTracks = args.Contains(
                 "--qa-audio-tracks",
                 StringComparer.OrdinalIgnoreCase);
+            IReadOnlyList<ProcessAudioRoute> advancedRoutes =
+                ParseQaProcessAudioRoutes(args);
+            bool advancedAudio = advancedRoutes.Count > 0;
+            int advancedMicrophoneTrack = ParseQaInt(
+                args,
+                "--qa-advanced-mic-track=",
+                0,
+                0,
+                6);
             string audioCodec = args
                 .FirstOrDefault(argument => argument.StartsWith(
                     "--qa-audio-codec=",
@@ -937,21 +958,32 @@ public partial class App : Application
                     Codec = codec,
                     AudioCodec = audioCodec,
                     CaptureSource = "desktop",
-                    CaptureSystemAudio = audioTracks,
+                    CaptureSystemAudio = !advancedAudio && audioTracks,
                     SystemAudioVolume = audioTracks ? 37 : 100,
-                    CaptureMicrophone = audioTracks,
+                    CaptureMicrophone = advancedAudio
+                        ? advancedMicrophoneTrack > 0
+                        : audioTracks,
                     MicrophoneVolume = audioTracks ? 63 : 100,
                     MicrophoneBoostDb = audioTracks ? 12 : 0,
                     SeparateAudioTracks = audioTracks,
+                    AudioRoutingMode = advancedAudio ? "advanced" : "simple",
+                    ProcessAudioRoutes = advancedRoutes.ToList(),
+                    AdvancedMicrophoneTrack = Math.Max(1, advancedMicrophoneTrack),
                     OutputDirectory = root,
                 };
-                bool started = TryStartPipeline(showError: false);
+                _config.Normalize();
+                bool started = advancedAudio
+                    ? await TryStartPipelineAsync(showError: false)
+                    : TryStartPipeline(showError: false);
                 if (!started ||
                     !string.Equals(_obs?.ActiveCodec, codec, StringComparison.OrdinalIgnoreCase))
                 {
                     allPassed = false;
                     Log.Write($"OBS_CODEC_TEST {codec}: start failed");
-                    StopPipeline();
+                    if (advancedAudio)
+                        await StopPipelineCoreAsync();
+                    else
+                        StopPipeline();
                     continue;
                 }
 
@@ -960,14 +992,20 @@ public partial class App : Application
                 Log.Write(
                     $"OBS_CODEC_TEST {codec}: source={_obs.Description}, " +
                     $"changed={sourceChanged}, game={_obs.ActiveGameExecutable}");
-                await Task.Delay(TimeSpan.FromSeconds(4));
-                string path = await _obs!.SaveReplayAsync();
+                await Task.Delay(TimeSpan.FromSeconds(recordingSeconds));
+                Task<string> saveOperation = advancedAudio
+                    ? await RunOnObsThreadAsync(() => _obs!.SaveReplayAsync())
+                    : _obs!.SaveReplayAsync();
+                string path = await saveOperation;
                 bool saved = File.Exists(path) && new FileInfo(path).Length > 0;
                 allPassed &= saved;
                 Log.Write(
                     $"OBS_CODEC_TEST {codec}: saved={saved}, " +
                     $"frames={_obs.EncodedFrameCount}, path={path}");
-                StopPipeline();
+                if (advancedAudio)
+                    await StopPipelineCoreAsync();
+                else
+                    StopPipeline();
             }
 
             Log.Write($"OBS_CODEC_TEST {(allPassed ? "PASS" : "FAIL")}");
@@ -1193,6 +1231,37 @@ public partial class App : Application
                int.TryParse(value[prefix.Length..], out int parsed)
             ? Math.Clamp(parsed, minimum, maximum)
             : fallback;
+    }
+
+    private static IReadOnlyList<ProcessAudioRoute> ParseQaProcessAudioRoutes(
+        IEnumerable<string> args)
+    {
+        const string prefix = "--qa-advanced-audio=";
+        string? value = args.FirstOrDefault(argument => argument.StartsWith(
+            prefix,
+            StringComparison.OrdinalIgnoreCase));
+        if (value is null)
+            return [];
+
+        var routes = new List<ProcessAudioRoute>();
+        foreach (string entry in value[prefix.Length..].Split(
+                     ',',
+                     StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            int separator = entry.LastIndexOf(':');
+            if (separator <= 0 ||
+                !int.TryParse(entry[(separator + 1)..], out int track))
+            {
+                throw new ArgumentException(
+                    "--qa-advanced-audio must use executable.exe:track entries.");
+            }
+            routes.Add(new ProcessAudioRoute
+            {
+                Executable = entry[..separator],
+                Track = track,
+            });
+        }
+        return routes;
     }
 #endif
 
@@ -1483,6 +1552,19 @@ public partial class App : Application
             _replayRunning = true;
             _captureDescription = description;
             _capabilities = engine.Capabilities;
+            _processAudioAvailability = engine.ProcessAudioAvailability;
+            if (string.Equals(
+                    _config.AudioRoutingMode,
+                    "advanced",
+                    StringComparison.OrdinalIgnoreCase) &&
+                _config.ProcessAudioRoutes.Count > 0)
+            {
+                _processAudioMonitor = new ProcessAudioMonitor(
+                    ProcessSnapshot.Capture,
+                    snapshot => RunOnObsThreadAsync(
+                        () => engine.ReconcileProcessAudio(snapshot)),
+                    Log.Write);
+            }
             if (!string.Equals(
                     requestedCodec,
                     _config.Codec,
@@ -1500,7 +1582,11 @@ public partial class App : Application
         catch (Exception exception)
         {
             if (engine is not null)
+            {
                 _capabilities = engine.Capabilities;
+                _processAudioAvailability = engine.ProcessAudioAvailability;
+            }
+            await StopProcessAudioMonitorAsync();
             _obs = null;
             _replayRunning = false;
             _captureDescription = null;
@@ -1537,6 +1623,7 @@ public partial class App : Application
 
     private async Task StopPipelineCoreAsync()
     {
+        await StopProcessAudioMonitorAsync();
         ObsReplayEngine? engine = _obs;
         _obs = null;
         _replayRunning = false;
@@ -1554,6 +1641,14 @@ public partial class App : Application
         {
             Log.Write($"OBS pipeline shutdown failed: {exception}");
         }
+    }
+
+    private async Task StopProcessAudioMonitorAsync()
+    {
+        ProcessAudioMonitor? monitor = _processAudioMonitor;
+        _processAudioMonitor = null;
+        if (monitor is not null)
+            await monitor.DisposeAsync();
     }
 
     private void StartHealthMonitor()
@@ -2860,6 +2955,7 @@ public partial class App : Application
         {
             if (!gracefulShutdownCompleted)
             {
+                StopProcessAudioMonitorAsync().GetAwaiter().GetResult();
                 gateHeld = _pipelineGate.Wait(TimeSpan.FromSeconds(50));
                 if (!gateHeld)
                     Log.Write("Timed out waiting for replay save during shutdown.");

--- a/src/Captail/BugReportInfo.cs
+++ b/src/Captail/BugReportInfo.cs
@@ -142,10 +142,18 @@ internal static class BugReportInfo
             FormatAudio(config));
     }
 
-    private static string FormatAudio(Config config)
+    internal static string FormatAudio(Config config)
     {
         var sources = new List<string>();
-        if (config.CaptureSystemAudio)
+        bool advanced = string.Equals(
+            config.AudioRoutingMode,
+            "advanced",
+            StringComparison.OrdinalIgnoreCase);
+        if (advanced)
+        {
+            sources.Add($"process audio ({config.ProcessAudioRoutes.Count} rules)");
+        }
+        else if (config.CaptureSystemAudio)
         {
             sources.Add(
                 $"{(config.CaptureSource == "game" ? "game" : "system")} audio " +
@@ -162,9 +170,11 @@ internal static class BugReportInfo
         if (sources.Count == 0)
             return "no audio";
 
-        string trackMode = config.SeparateAudioTracks && sources.Count > 1
-            ? "separate tracks"
-            : "mixed track";
+        string trackMode = advanced
+            ? $"{ObsReplayEngine.AudioTrackCount(config)} tracks"
+            : config.SeparateAudioTracks && sources.Count > 1
+                ? "separate tracks"
+                : "mixed track";
         return $"{string.Join(" + ", sources)}; {trackMode}; " +
                $"{config.AudioCodec.ToUpperInvariant()} " +
                $"{config.AudioBitrateKbps} kbps";

--- a/src/Captail/Captail.csproj
+++ b/src/Captail/Captail.csproj
@@ -51,7 +51,12 @@
     <AcquireObsRuntimeOnBuild Condition="'$(AcquireObsRuntimeOnBuild)' == ''">true</AcquireObsRuntimeOnBuild>
     <AcquireFfmpegRuntimeOnBuild Condition="'$(AcquireFfmpegRuntimeOnBuild)' == ''">true</AcquireFfmpegRuntimeOnBuild>
     <ObsBridgeSource>$(MSBuildProjectDirectory)\..\..\native\ObsBridge</ObsBridgeSource>
-    <ObsBridgeBuild>$(ObsBridgeSource)\build</ObsBridgeBuild>
+    <NativeBuildSuffix Condition="'$(NativeBuildSuffix)' == ''"></NativeBuildSuffix>
+    <ObsBridgeBuild>$(ObsBridgeSource)\build$(NativeBuildSuffix)</ObsBridgeBuild>
+    <ObsPluginSdkRoot>$(MSBuildProjectDirectory)\..\..\runtime\obs-sdk</ObsPluginSdkRoot>
+    <ProcessAudioSource>$(MSBuildProjectDirectory)\..\..\native\ProcessAudio</ProcessAudioSource>
+    <ProcessAudioBuild>$(ProcessAudioSource)\build$(NativeBuildSuffix)</ProcessAudioBuild>
+    <NativeCmakeGenerator Condition="'$(NativeCmakeGenerator)' == ''">Visual Studio 17 2022</NativeCmakeGenerator>
     <MpvWindowsX64Enabled>false</MpvWindowsX64Enabled>
     <MpvWindowsArm64Enabled>false</MpvWindowsArm64Enabled>
   </PropertyGroup>
@@ -75,6 +80,12 @@
           BeforeTargets="PrepareForBuild"
           Condition="'$(AcquireFfmpegRuntimeOnBuild)' == 'true' and !Exists('$(FfmpegRuntimeRoot)\ffmpeg.exe')">
     <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildProjectDirectory)\..\..\tools\AcquireFfmpegRuntime.ps1&quot;" />
+  </Target>
+
+  <Target Name="AcquireObsPluginSdk"
+          BeforeTargets="PrepareForBuild"
+          Condition="!Exists('$(ObsPluginSdkRoot)\include\obs-module.h')">
+    <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildProjectDirectory)\..\..\tools\AcquireObsPluginSdk.ps1&quot;" />
   </Target>
 
   <Target Name="CopyFfmpegRuntimeToBuild"
@@ -105,7 +116,7 @@
 
   <Target Name="BuildObsBridge" BeforeTargets="Build">
     <Exec Condition="!Exists('$(ObsBridgeBuild)\CaptailObsBridge.sln')"
-          Command="cmake -S &quot;$(ObsBridgeSource)&quot; -B &quot;$(ObsBridgeBuild)&quot; -G &quot;Visual Studio 17 2022&quot; -A x64" />
+          Command="cmake -S &quot;$(ObsBridgeSource)&quot; -B &quot;$(ObsBridgeBuild)&quot; -G &quot;$(NativeCmakeGenerator)&quot; -A x64" />
     <Exec Command="cmake --build &quot;$(ObsBridgeBuild)&quot; --config Release --target CaptailObsBridge" />
   </Target>
 
@@ -120,6 +131,29 @@
           Condition="'$(PublishDir)' != ''">
     <Copy SourceFiles="$(ObsBridgeBuild)\Release\CaptailObsBridge.dll"
           DestinationFolder="$(PublishDir)" />
+  </Target>
+
+  <Target Name="BuildProcessAudioPlugin"
+          BeforeTargets="Build"
+          DependsOnTargets="AcquireObsPluginSdk">
+    <Exec Condition="!Exists('$(ProcessAudioBuild)\CaptailProcessAudio.sln')"
+          Command="cmake -S &quot;$(ProcessAudioSource)&quot; -B &quot;$(ProcessAudioBuild)&quot; -G &quot;$(NativeCmakeGenerator)&quot; -A x64 -DOBS_INCLUDE_DIR=&quot;$(ObsPluginSdkRoot)\include&quot;" />
+    <Exec Command="cmake --build &quot;$(ProcessAudioBuild)&quot; --config Release --target CaptailProcessAudio" />
+  </Target>
+
+  <Target Name="CopyProcessAudioPlugin"
+          AfterTargets="Build"
+          DependsOnTargets="BuildProcessAudioPlugin">
+    <Copy SourceFiles="$(ProcessAudioBuild)\Release\captail-process-audio.dll"
+          DestinationFolder="$(OutDir)obs-plugins\64bit" />
+  </Target>
+
+  <Target Name="CopyProcessAudioPluginToPublish"
+          AfterTargets="Publish"
+          DependsOnTargets="BuildProcessAudioPlugin"
+          Condition="'$(PublishDir)' != ''">
+    <Copy SourceFiles="$(ProcessAudioBuild)\Release\captail-process-audio.dll"
+          DestinationFolder="$(PublishDir)obs-plugins\64bit" />
   </Target>
 
   <ItemGroup>

--- a/src/Captail/Config.cs
+++ b/src/Captail/Config.cs
@@ -52,6 +52,10 @@ public sealed class Config
     /// false mixes both sources into one track.
     /// </summary>
     public bool SeparateAudioTracks { get; set; }
+    /// <summary>"simple" preserves device loopback; "advanced" uses process rules.</summary>
+    public string AudioRoutingMode { get; set; } = "simple";
+    public List<ProcessAudioRoute> ProcessAudioRoutes { get; set; } = [];
+    public int AdvancedMicrophoneTrack { get; set; } = 1;
 
     public string OutputDirectory { get; set; } =
         Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyVideos), "Captail");
@@ -177,6 +181,16 @@ public sealed class Config
         AudioBitrateKbps = source.AudioBitrateKbps;
         AudioCodec = source.AudioCodec;
         SeparateAudioTracks = source.SeparateAudioTracks;
+        AudioRoutingMode = source.AudioRoutingMode;
+        ProcessAudioRoutes = (source.ProcessAudioRoutes ?? [])
+            .Where(route => route is not null)
+            .Select(route => new ProcessAudioRoute
+            {
+                Executable = route.Executable,
+                Track = route.Track,
+            })
+            .ToList();
+        AdvancedMicrophoneTrack = source.AdvancedMicrophoneTrack;
         OutputDirectory = source.OutputDirectory;
         OrganizeReplaysByGame = source.OrganizeReplaysByGame;
         Normalize();
@@ -201,6 +215,9 @@ public sealed class Config
         AudioBitrateKbps == other.AudioBitrateKbps &&
         string.Equals(AudioCodec, other.AudioCodec, StringComparison.Ordinal) &&
         SeparateAudioTracks == other.SeparateAudioTracks &&
+        string.Equals(AudioRoutingMode, other.AudioRoutingMode, StringComparison.Ordinal) &&
+        AdvancedMicrophoneTrack == other.AdvancedMicrophoneTrack &&
+        ProcessAudioRoutesEqual(ProcessAudioRoutes, other.ProcessAudioRoutes) &&
         string.Equals(OutputDirectory, other.OutputDirectory, StringComparison.OrdinalIgnoreCase) &&
         OrganizeReplaysByGame == other.OrganizeReplaysByGame;
 
@@ -238,7 +255,86 @@ public sealed class Config
         MicrophoneDeviceId = NormalizeIdentifier(MicrophoneDeviceId);
         AudioBitrateKbps = Math.Clamp(AudioBitrateKbps, 64, 512);
         AudioCodec = AllowedText(AudioCodec, ["aac", "opus"], "aac");
+        AudioRoutingMode = AllowedText(
+            AudioRoutingMode,
+            ["simple", "advanced"],
+            "simple");
+        AdvancedMicrophoneTrack = AdvancedMicrophoneTrack is >= 1 and <= 6
+            ? AdvancedMicrophoneTrack
+            : 1;
+        ProcessAudioRoutes = NormalizeProcessAudioRoutes(ProcessAudioRoutes);
         OutputDirectory = NormalizePath(OutputDirectory, allowEmpty: false);
+    }
+
+    private static List<ProcessAudioRoute> NormalizeProcessAudioRoutes(
+        IEnumerable<ProcessAudioRoute>? routes)
+    {
+        var normalized = new Dictionary<string, ProcessAudioRoute>(
+            StringComparer.OrdinalIgnoreCase);
+        foreach (ProcessAudioRoute? route in routes ?? [])
+        {
+            string executable = NormalizeExecutableName(route?.Executable);
+            if (executable.Length == 0 || route?.Track is not (>= 1 and <= 6))
+                continue;
+
+            // The first valid rule wins. This makes conflicting persisted
+            // entries deterministic without silently moving an existing route.
+            normalized.TryAdd(
+                executable,
+                new ProcessAudioRoute
+                {
+                    Executable = executable,
+                    Track = route.Track,
+                });
+        }
+        return normalized.Values
+            .OrderBy(route => route.Executable, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    internal static string NormalizeExecutableName(string? value)
+    {
+        string candidate = value?.Trim().Trim('"') ?? "";
+        if (candidate.Length == 0)
+            return "";
+        try
+        {
+            candidate = Path.GetFileName(candidate.Replace('/', '\\')).Trim();
+        }
+        catch
+        {
+            return "";
+        }
+        if (candidate.Length == 0 ||
+            candidate.Length > 260 ||
+            candidate.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+        {
+            return "";
+        }
+
+        string extension = Path.GetExtension(candidate);
+        if (extension.Length == 0)
+            candidate += ".exe";
+        else if (!string.Equals(extension, ".exe", StringComparison.OrdinalIgnoreCase))
+            return "";
+        else
+            candidate = candidate[..^extension.Length] + ".exe";
+        return candidate.ToLowerInvariant();
+    }
+
+    private static bool ProcessAudioRoutesEqual(
+        IReadOnlyList<ProcessAudioRoute>? left,
+        IReadOnlyList<ProcessAudioRoute>? right)
+    {
+        ProcessAudioRoute[] leftRoutes = NormalizeProcessAudioRoutes(left).ToArray();
+        ProcessAudioRoute[] rightRoutes = NormalizeProcessAudioRoutes(right).ToArray();
+        return leftRoutes.Length == rightRoutes.Length &&
+               leftRoutes.Zip(rightRoutes).All(pair =>
+                   pair.First.Track == pair.Second.Track &&
+                   string.Equals(
+                       pair.First.Executable,
+                       pair.Second.Executable,
+                       StringComparison.OrdinalIgnoreCase));
     }
 
     private static int AllowedValue(int value, int[] allowed, int fallback) =>
@@ -291,4 +387,10 @@ public sealed class Config
 
     private static string NormalizeLanguage(string? language) =>
         Localization.NormalizeLanguage(language);
+}
+
+public sealed class ProcessAudioRoute
+{
+    public string Executable { get; set; } = "";
+    public int Track { get; set; } = 1;
 }

--- a/src/Captail/Interop/ProcessTopology.cs
+++ b/src/Captail/Interop/ProcessTopology.cs
@@ -1,0 +1,313 @@
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Win32.SafeHandles;
+
+namespace Captail.Interop;
+
+internal readonly record struct ProcessIdentity(uint ProcessId, long CreationTime);
+
+internal sealed record ProcessNode(
+    ProcessIdentity Identity,
+    uint ParentProcessId,
+    string Executable)
+{
+    internal ProcessIdentity? ParentIdentity { get; init; }
+}
+
+internal sealed class ProcessSnapshot
+{
+    private readonly IReadOnlyDictionary<ProcessIdentity, ProcessNode> _nodes;
+
+    private ProcessSnapshot(IEnumerable<ProcessNode> nodes)
+    {
+        ProcessNode[] materialized = nodes.ToArray();
+        var byProcessId = new Dictionary<uint, ProcessNode>();
+        foreach (ProcessNode node in materialized)
+        {
+            if (!byProcessId.TryAdd(node.Identity.ProcessId, node))
+                throw new ArgumentException("A process snapshot cannot contain duplicate process IDs.");
+        }
+
+        var validated = new Dictionary<ProcessIdentity, ProcessNode>();
+        foreach (ProcessNode node in materialized)
+        {
+            ProcessIdentity? parentIdentity = null;
+            if (node.ParentProcessId != 0 &&
+                node.ParentProcessId != node.Identity.ProcessId &&
+                byProcessId.TryGetValue(node.ParentProcessId, out ProcessNode? parent) &&
+                parent.Identity.CreationTime < node.Identity.CreationTime)
+            {
+                parentIdentity = parent.Identity;
+            }
+
+            ProcessNode validatedNode = node with { ParentIdentity = parentIdentity };
+            validated.Add(validatedNode.Identity, validatedNode);
+        }
+
+        _nodes = validated;
+    }
+
+    internal IReadOnlyCollection<ProcessNode> Nodes => _nodes.Values.ToArray();
+
+    internal static ProcessSnapshot CreateSynthetic(IEnumerable<ProcessNode> nodes) => new(nodes);
+
+    internal static ProcessSnapshot Capture()
+    {
+        if (!ProcessNative.ProcessIdToSessionId(
+                checked((uint)Environment.ProcessId),
+                out uint currentSessionId))
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        using ProcessNative.SafeSnapshotHandle snapshot =
+            ProcessNative.CreateToolhelp32Snapshot(
+            ProcessNative.Th32csSnapProcess,
+            0);
+        if (snapshot.IsInvalid)
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+
+        var nodes = new List<ProcessNode>();
+        var entry = new ProcessNative.ProcessEntry32
+        {
+            Size = checked((uint)Marshal.SizeOf<ProcessNative.ProcessEntry32>()),
+            ExecutableFile = "",
+        };
+
+        if (!ProcessNative.Process32First(snapshot, ref entry))
+        {
+            int error = Marshal.GetLastWin32Error();
+            if (error == ProcessNative.ErrorNoMoreFiles)
+                return new ProcessSnapshot(nodes);
+            throw new Win32Exception(error);
+        }
+
+        do
+        {
+            TryAddProcess(entry, currentSessionId, nodes);
+            entry.Size = checked((uint)Marshal.SizeOf<ProcessNative.ProcessEntry32>());
+        }
+        while (ProcessNative.Process32Next(snapshot, ref entry));
+
+        int finalError = Marshal.GetLastWin32Error();
+        if (finalError != ProcessNative.ErrorNoMoreFiles)
+            throw new Win32Exception(finalError);
+        return new ProcessSnapshot(nodes);
+    }
+
+    internal IReadOnlyList<ProcessNode> SelectIndependentRoots(
+        IEnumerable<string> executableTargets)
+    {
+        var targets = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (string target in executableTargets)
+        {
+            string normalized = NormalizeExecutable(target);
+            if (normalized.Length > 0)
+                targets.Add(normalized);
+        }
+
+        if (targets.Count == 0)
+            return [];
+
+        ProcessNode[] candidates = _nodes.Values
+            .Where(node => targets.Contains(node.Executable))
+            .OrderBy(NodeDepth)
+            .ThenBy(node => node.Identity.CreationTime)
+            .ThenBy(node => node.Identity.ProcessId)
+            .ToArray();
+
+        var selectedIdentities = new HashSet<ProcessIdentity>();
+        var selected = new List<ProcessNode>();
+        foreach (ProcessNode candidate in candidates)
+        {
+            if (HasSelectedAncestor(candidate, selectedIdentities))
+                continue;
+            selected.Add(candidate);
+            selectedIdentities.Add(candidate.Identity);
+        }
+        return selected;
+    }
+
+    internal static string NormalizeExecutable(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return "";
+        return Path.GetFileName(value.Trim()).Trim();
+    }
+
+    private static void TryAddProcess(
+        ProcessNative.ProcessEntry32 entry,
+        uint currentSessionId,
+        ICollection<ProcessNode> nodes)
+    {
+        uint processId = entry.ProcessId;
+        if (processId == 0 || processId == Environment.ProcessId ||
+            !ProcessNative.ProcessIdToSessionId(processId, out uint sessionId) ||
+            sessionId != currentSessionId)
+        {
+            return;
+        }
+
+        using SafeProcessHandle process = ProcessNative.OpenProcess(
+            ProcessNative.ProcessQueryLimitedInformation,
+            false,
+            processId);
+        if (process.IsInvalid ||
+            !ProcessNative.GetProcessTimes(
+                process,
+                out ProcessNative.FileTime creationTime,
+                out _,
+                out _,
+                out _))
+        {
+            return;
+        }
+
+        string executable = QueryExecutable(process);
+        if (executable.Length == 0)
+            executable = NormalizeExecutable(entry.ExecutableFile);
+        if (executable.Length == 0)
+            return;
+
+        long creation = unchecked((long)(
+            ((ulong)creationTime.HighDateTime << 32) |
+            creationTime.LowDateTime));
+        nodes.Add(new ProcessNode(
+            new ProcessIdentity(processId, creation),
+            entry.ParentProcessId,
+            executable));
+    }
+
+    private static string QueryExecutable(SafeProcessHandle process)
+    {
+        uint capacity = 1024;
+        var buffer = new StringBuilder(checked((int)capacity));
+        if (!ProcessNative.QueryFullProcessImageName(process, 0, buffer, ref capacity))
+            return "";
+        return NormalizeExecutable(buffer.ToString());
+    }
+
+    private bool HasSelectedAncestor(
+        ProcessNode node,
+        IReadOnlySet<ProcessIdentity> selected)
+    {
+        var visited = new HashSet<ProcessIdentity> { node.Identity };
+        ProcessIdentity? parentIdentity = node.ParentIdentity;
+        while (parentIdentity is ProcessIdentity parent)
+        {
+            if (!visited.Add(parent))
+                return false;
+            if (selected.Contains(parent))
+                return true;
+            if (!_nodes.TryGetValue(parent, out ProcessNode? parentNode))
+                return false;
+            parentIdentity = parentNode.ParentIdentity;
+        }
+        return false;
+    }
+
+    private int NodeDepth(ProcessNode node)
+    {
+        int depth = 0;
+        var visited = new HashSet<ProcessIdentity> { node.Identity };
+        ProcessIdentity? parentIdentity = node.ParentIdentity;
+        while (parentIdentity is ProcessIdentity parent &&
+               visited.Add(parent) &&
+               _nodes.TryGetValue(parent, out ProcessNode? parentNode))
+        {
+            depth++;
+            parentIdentity = parentNode.ParentIdentity;
+        }
+        return depth;
+    }
+}
+
+internal static class ProcessNative
+{
+    internal const uint Th32csSnapProcess = 0x00000002;
+    internal const uint ProcessQueryLimitedInformation = 0x00001000;
+    internal const int ErrorNoMoreFiles = 18;
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct FileTime
+    {
+        internal uint LowDateTime;
+        internal uint HighDateTime;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    internal struct ProcessEntry32
+    {
+        internal uint Size;
+        internal uint Usage;
+        internal uint ProcessId;
+        internal nuint DefaultHeapId;
+        internal uint ModuleId;
+        internal uint Threads;
+        internal uint ParentProcessId;
+        internal int BasePriority;
+        internal uint Flags;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
+        internal string ExecutableFile;
+    }
+
+    internal sealed class SafeSnapshotHandle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        internal SafeSnapshotHandle() : base(true) { }
+
+        protected override bool ReleaseHandle() => CloseHandle(handle);
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    internal static extern SafeSnapshotHandle CreateToolhelp32Snapshot(
+        uint flags,
+        uint processId);
+
+    [DllImport("kernel32.dll", EntryPoint = "Process32FirstW", CharSet = CharSet.Unicode,
+        SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool Process32First(
+        SafeSnapshotHandle snapshot,
+        ref ProcessEntry32 entry);
+
+    [DllImport("kernel32.dll", EntryPoint = "Process32NextW", CharSet = CharSet.Unicode,
+        SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool Process32Next(
+        SafeSnapshotHandle snapshot,
+        ref ProcessEntry32 entry);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    internal static extern SafeProcessHandle OpenProcess(
+        uint desiredAccess,
+        [MarshalAs(UnmanagedType.Bool)] bool inheritHandle,
+        uint processId);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool GetProcessTimes(
+        SafeProcessHandle process,
+        out FileTime creationTime,
+        out FileTime exitTime,
+        out FileTime kernelTime,
+        out FileTime userTime);
+
+    [DllImport("kernel32.dll", EntryPoint = "QueryFullProcessImageNameW",
+        CharSet = CharSet.Unicode, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool QueryFullProcessImageName(
+        SafeProcessHandle process,
+        uint flags,
+        StringBuilder executableName,
+        ref uint size);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool ProcessIdToSessionId(uint processId, out uint sessionId);
+
+    [DllImport("kernel32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CloseHandle(nint handle);
+}

--- a/src/Captail/ObsNative.cs
+++ b/src/Captail/ObsNative.cs
@@ -100,6 +100,10 @@ internal static class ObsNative
     internal static extern bool obs_enum_encoder_types(nuint index, out nint id);
 
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    [return: MarshalAs(UnmanagedType.I1)]
+    internal static extern bool obs_enum_input_types(nuint index, out nint id);
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
     internal static extern void obs_enter_graphics();
 
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
@@ -146,6 +150,22 @@ internal static class ObsNative
 
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
     internal static extern nint obs_get_audio();
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern nint obs_scene_create(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern nint obs_scene_get_source(nint scene);
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern nint obs_scene_add(nint scene, nint source);
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void obs_sceneitem_remove(nint sceneItem);
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void obs_scene_release(nint scene);
 
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
     internal static extern uint obs_get_total_frames();
@@ -345,5 +365,13 @@ internal static class ObsNative
         ref CallData callData,
         [MarshalAs(UnmanagedType.LPUTF8Str)] string name,
         out byte value,
+        nuint size);
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    [return: MarshalAs(UnmanagedType.I1)]
+    internal static extern bool calldata_get_data(
+        ref CallData callData,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string name,
+        out long value,
         nuint size);
 }

--- a/src/Captail/ObsReplayEngine.cs
+++ b/src/Captail/ObsReplayEngine.cs
@@ -5,6 +5,20 @@ using Captail.Interop;
 
 namespace Captail;
 
+internal enum AdvancedProcessAudioAvailability
+{
+    Available,
+    UnsupportedWindowsVersion,
+    SourceUnavailable,
+}
+
+internal sealed class AdvancedProcessAudioUnavailableException(
+    AdvancedProcessAudioAvailability availability)
+    : InvalidOperationException(Localization.Text("L.Engine.AudioFailed"))
+{
+    internal AdvancedProcessAudioAvailability Availability { get; } = availability;
+}
+
 [SuppressMessage(
     "Usage",
     "CA2216:Disposable types should declare finalizer",
@@ -20,6 +34,7 @@ public sealed class ObsReplayEngine : IDisposable
     private const int GameCaptureIdleReleaseSeconds = 10;
     private const int GameCaptureDetectorStartupSeconds = 8;
     private const int Windows11InitialBuild = 22000;
+    private const int ProcessLoopbackMinimumBuild = 19041;
     private const long MonitorCaptureMethodAuto = 0;
     private const long MonitorCaptureMethodWgc = 2;
     private static readonly string[] CapabilityCodecNames = ["h264", "hevc", "av1"];
@@ -60,6 +75,9 @@ public sealed class ObsReplayEngine : IDisposable
     private readonly ObsNative.SignalCallback _stoppedCallback;
     private readonly List<nint> _audioSources = [];
     private readonly List<nint> _audioEncoders = [];
+    private readonly Dictionary<nint, nint> _processAudioSceneItems = [];
+    private ProcessAudioReconciler? _processAudioReconciler;
+    private int _processAudioSourceNumber;
 
     private nint _videoSource;
     private nint _desktopVideoSource;
@@ -67,6 +85,7 @@ public sealed class ObsReplayEngine : IDisposable
     private nint _videoEncoder;
     private nint _output;
     private nint _outputSignals;
+    private nint _processAudioScene;
     private TaskCompletionSource<string>? _pendingSave;
     private bool _started;
     private bool _obsStarted;
@@ -103,6 +122,11 @@ public sealed class ObsReplayEngine : IDisposable
     public EncoderCapabilities Capabilities { get; private set; } =
         EncoderCapabilities.Failed(
             Localization.Text("L.Engine.CapabilitiesPending"));
+    internal AdvancedProcessAudioAvailability ProcessAudioAvailability
+    {
+        get;
+        private set;
+    } = AdvancedProcessAudioAvailability.SourceUnavailable;
     public bool IsGameCapture { get; }
     public bool IsAutomaticCapture { get; }
     internal bool IsGameCaptureDetectorActive => _gameCaptureDetectorShowing;
@@ -552,6 +576,14 @@ public sealed class ObsReplayEngine : IDisposable
         {
             InitializeObs();
             Capabilities = DetectCapabilities();
+            ProcessAudioAvailability = DetectProcessAudioAvailability(
+                Environment.OSVersion.Version,
+                HasInputType("captail_process_audio_capture"));
+            if (!IsAudioRoutingAvailable(_config, ProcessAudioAvailability))
+            {
+                throw new AdvancedProcessAudioUnavailableException(
+                    ProcessAudioAvailability);
+            }
             EnsureConfiguredCodecIsSupported();
             CreateSources();
             CreateEncoders();
@@ -1052,7 +1084,21 @@ public sealed class ObsReplayEngine : IDisposable
         // extra scene-composition pass, which matters at 144/240 FPS.
         ObsNative.obs_set_output_source(0, _videoSource);
 
-        if (_config.CaptureSystemAudio)
+        if (IsAdvancedAudioRouting)
+        {
+            _processAudioScene = ObsNative.obs_scene_create(
+                "Captail Process Audio Mixer");
+            if (_processAudioScene == 0)
+            {
+                throw new InvalidOperationException(
+                    "Could not create the advanced process audio mixer.");
+            }
+            nint sceneSource = ObsNative.obs_scene_get_source(_processAudioScene);
+            ObsNative.obs_source_set_audio_mixers(sceneSource, 0x3Fu);
+            ObsNative.obs_set_output_source(1, sceneSource);
+        }
+
+        if (!IsAdvancedAudioRouting && _config.CaptureSystemAudio)
         {
             nint system = CreateAudioSource(
                 "wasapi_output_capture",
@@ -1066,10 +1112,11 @@ public sealed class ObsReplayEngine : IDisposable
 
         if (_config.CaptureMicrophone)
         {
-            uint micMix = _config.SeparateAudioTracks &&
-                          _config.CaptureSystemAudio
-                ? 2u
-                : 1u;
+            uint micMix = IsAdvancedAudioRouting
+                ? MixerBit(_config.AdvancedMicrophoneTrack)
+                : _config.SeparateAudioTracks && _config.CaptureSystemAudio
+                    ? 2u
+                    : 1u;
             nint microphone = CreateAudioSource(
                 "wasapi_input_capture",
                 "Captail Microphone",
@@ -1202,6 +1249,104 @@ public sealed class ObsReplayEngine : IDisposable
     private static float DecibelsToLinear(int decibels) =>
         MathF.Pow(10f, Math.Clamp(decibels, 0, 20) / 20f);
 
+    internal ProcessAudioReconcileResult ReconcileProcessAudio(
+        ProcessSnapshot snapshot)
+    {
+        ObjectDisposedException.ThrowIf(_disposing, this);
+        if (!_obsStarted)
+            throw new InvalidOperationException("The OBS pipeline is not initialized.");
+
+        _processAudioReconciler ??= new ProcessAudioReconciler(
+            CreateProcessAudioSource,
+            DestroyProcessAudioSource,
+            Log.Write);
+        return _processAudioReconciler.Reconcile(
+            snapshot,
+            _config.ProcessAudioRoutes.Select(route =>
+                new ProcessAudioTarget(route.Executable, route.Track)));
+    }
+
+    private nint CreateProcessAudioSource(ProcessIdentity identity, int track)
+    {
+        nint settings = ObsNative.obs_data_create();
+        try
+        {
+            ObsNative.obs_data_set_int(settings, "target_pid", identity.ProcessId);
+            ObsNative.obs_data_set_int(
+                settings,
+                "target_creation_time",
+                identity.CreationTime);
+            nint source = ObsNative.obs_source_create(
+                "captail_process_audio_capture",
+                $"Captail Process Audio {++_processAudioSourceNumber}",
+                settings,
+                0);
+            if (source == 0)
+                return 0;
+            if (!HasProcessAudioStatus(source))
+            {
+                ObsNative.obs_source_remove(source);
+                ObsNative.obs_source_release(source);
+                return 0;
+            }
+
+            ObsNative.obs_source_set_audio_mixers(source, MixerBit(track));
+            nint sceneItem = ObsNative.obs_scene_add(_processAudioScene, source);
+            if (sceneItem == 0)
+            {
+                ObsNative.obs_source_remove(source);
+                ObsNative.obs_source_release(source);
+                return 0;
+            }
+            _processAudioSceneItems.Add(source, sceneItem);
+            return source;
+        }
+        finally
+        {
+            ObsNative.obs_data_release(settings);
+        }
+    }
+
+    private void DestroyProcessAudioSource(nint source)
+    {
+        if (_processAudioSceneItems.Remove(source, out nint sceneItem))
+            ObsNative.obs_sceneitem_remove(sceneItem);
+        ObsNative.obs_source_remove(source);
+        ObsNative.obs_source_release(source);
+    }
+
+    private static bool HasProcessAudioStatus(nint source)
+    {
+        nint handler = ObsNative.obs_source_get_proc_handler(source);
+        if (handler == 0)
+            return false;
+
+        const int stackSize = 256;
+        nint stack = Marshal.AllocHGlobal(stackSize);
+        try
+        {
+            for (int offset = 0; offset < stackSize; offset += sizeof(long))
+                Marshal.WriteInt64(stack, offset, 0);
+            var callData = new ObsNative.CallData
+            {
+                Stack = stack,
+                Size = (nuint)nint.Size,
+                Capacity = stackSize,
+                Fixed = true,
+            };
+            return ObsNative.proc_handler_call(handler, "get_status", ref callData) &&
+                   ObsNative.calldata_get_data(
+                       ref callData,
+                       "state",
+                       out long _,
+                       sizeof(long));
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(stack);
+        }
+    }
+
     private void CreateEncoders()
     {
         EncoderLoadProfile loadProfile = SelectLoadProfile();
@@ -1260,9 +1405,12 @@ public sealed class ObsReplayEngine : IDisposable
                     audioSettings,
                     "bitrate",
                     _config.AudioBitrateKbps);
+                string encoderName = IsAdvancedAudioRouting
+                    ? $"Captail Audio Track {index + 1}"
+                    : $"Captail Audio {index + 1}";
                 nint encoder = ObsNative.obs_audio_encoder_create(
                     audioEncoderId,
-                    $"Captail Audio {index + 1}",
+                    encoderName,
                     audioSettings,
                     (nuint)index,
                     0);
@@ -1667,12 +1815,80 @@ public sealed class ObsReplayEngine : IDisposable
     }
 
     private int AudioTrackCount()
+        => AudioTrackCount(_config);
+
+    internal static uint MixerBit(int track)
     {
-        int enabled = (_config.CaptureSystemAudio ? 1 : 0) +
-                      (_config.CaptureMicrophone ? 1 : 0);
+        if (track is not (>= 1 and <= 6))
+            throw new ArgumentOutOfRangeException(nameof(track));
+        return 1u << (track - 1);
+    }
+
+    internal static int AudioTrackCount(Config config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        if (string.Equals(
+                config.AudioRoutingMode,
+                "advanced",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            int highest = config.ProcessAudioRoutes.Count == 0
+                ? 1
+                : config.ProcessAudioRoutes.Max(route => route.Track);
+            if (config.CaptureMicrophone)
+                highest = Math.Max(highest, config.AdvancedMicrophoneTrack);
+            return highest;
+        }
+
+        int enabled = (config.CaptureSystemAudio ? 1 : 0) +
+                      (config.CaptureMicrophone ? 1 : 0);
         if (enabled == 0)
-            return 1; // Replay Buffer requires an audio encoder; this track remains silent.
-        return _config.SeparateAudioTracks && enabled > 1 ? 2 : 1;
+            return 1;
+        return config.SeparateAudioTracks && enabled > 1 ? 2 : 1;
+    }
+
+    internal static AdvancedProcessAudioAvailability DetectProcessAudioAvailability(
+        Version windowsVersion,
+        bool sourceRegistered)
+    {
+        ArgumentNullException.ThrowIfNull(windowsVersion);
+        if (windowsVersion.Major < 10 ||
+            windowsVersion.Major == 10 && windowsVersion.Build < ProcessLoopbackMinimumBuild)
+        {
+            return AdvancedProcessAudioAvailability.UnsupportedWindowsVersion;
+        }
+        return sourceRegistered
+            ? AdvancedProcessAudioAvailability.Available
+            : AdvancedProcessAudioAvailability.SourceUnavailable;
+    }
+
+    internal static bool IsAudioRoutingAvailable(
+        Config config,
+        AdvancedProcessAudioAvailability processAudioAvailability)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        return !string.Equals(
+                   config.AudioRoutingMode,
+                   "advanced",
+                   StringComparison.OrdinalIgnoreCase) ||
+               processAudioAvailability == AdvancedProcessAudioAvailability.Available;
+    }
+
+    private bool IsAdvancedAudioRouting => string.Equals(
+        _config.AudioRoutingMode,
+        "advanced",
+        StringComparison.OrdinalIgnoreCase);
+
+    private static bool HasInputType(string expected)
+    {
+        for (nuint index = 0;
+             ObsNative.obs_enum_input_types(index, out nint id);
+             index++)
+        {
+            if (string.Equals(PtrToString(id), expected, StringComparison.Ordinal))
+                return true;
+        }
+        return false;
     }
 
     private void OnReplaySaved(nint _, nint __)
@@ -1858,6 +2074,10 @@ public sealed class ObsReplayEngine : IDisposable
             _gameCaptureDetectorShowing = false;
         }
 
+        _processAudioReconciler?.Dispose();
+        _processAudioReconciler = null;
+        _processAudioSceneItems.Clear();
+
         if (_desktopVideoSource != 0)
             ObsNative.obs_source_remove(_desktopVideoSource);
         if (_gameVideoSource != 0)
@@ -1879,6 +2099,11 @@ public sealed class ObsReplayEngine : IDisposable
         foreach (nint source in _audioSources)
             ObsNative.obs_source_release(source);
         _audioSources.Clear();
+        if (_processAudioScene != 0)
+        {
+            ObsNative.obs_scene_release(_processAudioScene);
+            _processAudioScene = 0;
+        }
 
         ObsNative.obs_wait_for_destroy_queue();
         ObsNative.obs_shutdown();

--- a/src/Captail/ProcessAudioMonitor.cs
+++ b/src/Captail/ProcessAudioMonitor.cs
@@ -1,0 +1,110 @@
+using Captail.Interop;
+
+namespace Captail;
+
+internal sealed class ProcessAudioPollCadence
+{
+    internal static readonly TimeSpan SteadyInterval = TimeSpan.FromMilliseconds(1000);
+    internal static readonly TimeSpan ReacquisitionInterval = TimeSpan.FromMilliseconds(250);
+    private const int ReacquisitionPolls = 8;
+
+    private int _remainingFastPolls;
+    private int? _previousDesiredSources;
+
+    internal TimeSpan NextInterval => _remainingFastPolls > 0
+        ? ReacquisitionInterval
+        : SteadyInterval;
+
+    internal void Observe(ProcessAudioReconcileResult result)
+    {
+        bool topologyChanged =
+            (_previousDesiredSources is int previous &&
+             previous != result.DesiredSources) ||
+            result.CreatedSources > 0 ||
+            result.DestroyedSources > 0;
+        _previousDesiredSources = result.DesiredSources;
+
+        if (topologyChanged)
+            _remainingFastPolls = ReacquisitionPolls;
+        else if (_remainingFastPolls > 0)
+            _remainingFastPolls--;
+    }
+}
+
+internal sealed class ProcessAudioMonitor : IAsyncDisposable
+{
+    private readonly Func<ProcessSnapshot> _captureSnapshot;
+    private readonly Func<ProcessSnapshot, Task<ProcessAudioReconcileResult>>
+        _reconcile;
+    private readonly Action<string>? _log;
+    private readonly CancellationTokenSource _cancellation = new();
+    private readonly Task _worker;
+    private int _disposed;
+
+    internal ProcessAudioMonitor(
+        Func<ProcessSnapshot> captureSnapshot,
+        Func<ProcessSnapshot, Task<ProcessAudioReconcileResult>> reconcile,
+        Action<string>? log = null)
+    {
+        _captureSnapshot = captureSnapshot;
+        _reconcile = reconcile;
+        _log = log;
+        _worker = Task.Run(RunAsync);
+    }
+
+    private async Task RunAsync()
+    {
+        var cadence = new ProcessAudioPollCadence();
+        while (!_cancellation.IsCancellationRequested)
+        {
+            try
+            {
+                ProcessSnapshot snapshot = _captureSnapshot();
+                ProcessAudioReconcileResult result = await _reconcile(snapshot);
+                cadence.Observe(result);
+                if (result.CreatedSources > 0 ||
+                    result.DestroyedSources > 0 ||
+                    result.FailedSources > 0)
+                {
+                    _log?.Invoke(
+                        $"Process audio reconciliation: desired={result.DesiredSources}, " +
+                        $"active={result.ActiveSources}, created={result.CreatedSources}, " +
+                        $"destroyed={result.DestroyedSources}, failed={result.FailedSources}.");
+                }
+            }
+            catch (OperationCanceledException) when (_cancellation.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception exception)
+            {
+                _log?.Invoke(
+                    $"Process audio reconciliation failed ({exception.GetType().Name}).");
+            }
+
+            try
+            {
+                await Task.Delay(cadence.NextInterval, _cancellation.Token);
+            }
+            catch (OperationCanceledException) when (_cancellation.IsCancellationRequested)
+            {
+                break;
+            }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+        _cancellation.Cancel();
+        try
+        {
+            await _worker;
+        }
+        finally
+        {
+            _cancellation.Dispose();
+        }
+    }
+}

--- a/src/Captail/ProcessAudioReconciler.cs
+++ b/src/Captail/ProcessAudioReconciler.cs
@@ -1,0 +1,151 @@
+using Captail.Interop;
+
+namespace Captail;
+
+internal sealed record ProcessAudioReconcileResult(
+    int DesiredSources,
+    int ActiveSources,
+    int CreatedSources,
+    int DestroyedSources,
+    int FailedSources);
+
+internal sealed record ProcessAudioTarget(string Executable, int Track);
+
+internal sealed record ActiveProcessAudioSource(nint Source, int Track);
+
+internal sealed class ProcessAudioReconciler : IDisposable
+{
+    private readonly int _ownerThreadId = Environment.CurrentManagedThreadId;
+    private readonly Func<ProcessIdentity, int, nint> _createSource;
+    private readonly Action<nint> _destroySource;
+    private readonly Action<string>? _log;
+    private readonly Dictionary<ProcessIdentity, ActiveProcessAudioSource>
+        _activeSources = [];
+    private bool _disposed;
+
+    internal ProcessAudioReconciler(
+        Func<ProcessIdentity, int, nint> createSource,
+        Action<nint> destroySource,
+        Action<string>? log = null)
+    {
+        _createSource = createSource;
+        _destroySource = destroySource;
+        _log = log;
+    }
+
+    internal IReadOnlyCollection<ProcessIdentity> ActiveIdentities =>
+        _activeSources.Keys.ToArray();
+
+    internal IReadOnlyDictionary<ProcessIdentity, int> ActiveTracks =>
+        _activeSources.ToDictionary(item => item.Key, item => item.Value.Track);
+
+    internal ProcessAudioReconcileResult Reconcile(
+        ProcessSnapshot snapshot,
+        IEnumerable<ProcessAudioTarget> executableTargets)
+    {
+        EnsureOwnerThread();
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        var targets = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (ProcessAudioTarget target in executableTargets)
+        {
+            if (target.Track is >= 1 and <= 6)
+                targets.TryAdd(target.Executable, target.Track);
+        }
+
+        ProcessNode[] desiredRoots = snapshot
+            .SelectIndependentRoots(targets.Keys)
+            .ToArray();
+        var desired = desiredRoots.ToDictionary(
+            node => node.Identity,
+            node => targets[node.Executable]);
+
+        int destroyed = 0;
+        int failed = 0;
+        ProcessIdentity[] obsolete = _activeSources.Keys
+            .Where(identity =>
+                !desired.TryGetValue(identity, out int track) ||
+                _activeSources[identity].Track != track)
+            .OrderBy(identity => identity.CreationTime)
+            .ThenBy(identity => identity.ProcessId)
+            .ToArray();
+        foreach (ProcessIdentity identity in obsolete)
+        {
+            nint source = _activeSources[identity].Source;
+            _activeSources.Remove(identity);
+            try
+            {
+                _destroySource(source);
+                destroyed++;
+            }
+            catch (Exception exception)
+            {
+                failed++;
+                _log?.Invoke(
+                    $"Process audio source cleanup failed ({exception.GetType().Name}).");
+            }
+        }
+
+        int created = 0;
+        foreach (ProcessNode root in desiredRoots)
+        {
+            if (_activeSources.ContainsKey(root.Identity))
+                continue;
+            try
+            {
+                int track = desired[root.Identity];
+                nint source = _createSource(root.Identity, track);
+                if (source == 0)
+                    throw new InvalidOperationException("Native source creation returned null.");
+                _activeSources.Add(
+                    root.Identity,
+                    new ActiveProcessAudioSource(source, track));
+                created++;
+            }
+            catch (Exception exception)
+            {
+                failed++;
+                _log?.Invoke(
+                    $"Process audio source creation failed ({exception.GetType().Name}).");
+            }
+        }
+
+        return new ProcessAudioReconcileResult(
+            desired.Count,
+            _activeSources.Count,
+            created,
+            destroyed,
+            failed);
+    }
+
+    public void Dispose()
+    {
+        EnsureOwnerThread();
+        if (_disposed)
+            return;
+        _disposed = true;
+
+        foreach (ActiveProcessAudioSource active in _activeSources.Values.Reverse())
+        {
+            try
+            {
+                _destroySource(active.Source);
+            }
+            catch (Exception exception)
+            {
+                _log?.Invoke(
+                    $"Process audio source cleanup failed ({exception.GetType().Name}).");
+            }
+        }
+        _activeSources.Clear();
+    }
+
+    private void EnsureOwnerThread()
+    {
+        if (Environment.CurrentManagedThreadId != _ownerThreadId)
+        {
+            throw new InvalidOperationException(
+                "Process audio sources must be reconciled on their owning OBS thread.");
+        }
+    }
+}

--- a/src/Captail/Properties/AssemblyInfo.cs
+++ b/src/Captail/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("ProcessAudioFoundationQa")]
+[assembly: InternalsVisibleTo("ProcessAudioQa")]

--- a/tools/AcquireObsPluginSdk.ps1
+++ b/tools/AcquireObsPluginSdk.ps1
@@ -1,0 +1,109 @@
+[CmdletBinding()]
+param(
+    [string]$Destination = ""
+)
+
+$ErrorActionPreference = "Stop"
+$version = "32.1.2"
+$expectedArchiveSha256 = "21cba22292985cf0da967d5c618999b40eaa32b73d2ab8b06154b5ea1b3d3798"
+$repoRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot ".."))
+$runtimeRoot = [IO.Path]::GetFullPath((Join-Path $repoRoot "runtime"))
+if (-not $Destination) {
+    $Destination = Join-Path $runtimeRoot "obs-sdk"
+}
+$Destination = [IO.Path]::GetFullPath($Destination)
+$allowedPrefix = $runtimeRoot.TrimEnd(
+    [IO.Path]::DirectorySeparatorChar,
+    [IO.Path]::AltDirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar
+if (-not $Destination.StartsWith(
+        $allowedPrefix,
+        [StringComparison]::OrdinalIgnoreCase)) {
+    throw "OBS SDK destination must stay under $runtimeRoot"
+}
+
+$marker = Join-Path $Destination "VERSION"
+$header = Join-Path $Destination "include\obs-module.h"
+$generatedConfig = Join-Path $Destination "include\obsconfig.h"
+$sourceHashMarker = Join-Path $Destination "SOURCE_SHA256"
+if ((Test-Path -LiteralPath $header) -and
+    (Test-Path -LiteralPath $generatedConfig) -and
+    (Test-Path -LiteralPath $marker) -and
+    (Test-Path -LiteralPath $sourceHashMarker) -and
+    ((Get-Content -LiteralPath $marker -Raw).Trim() -eq $version) -and
+    ((Get-Content -LiteralPath $sourceHashMarker -Raw).Trim() -eq
+        $expectedArchiveSha256)) {
+    Write-Host "OBS plugin headers $version ready: $Destination"
+    return
+}
+
+$archive = Join-Path $env:TEMP "obs-studio-$version-source.zip"
+if (Test-Path -LiteralPath $archive) {
+    $existingHash = (Get-FileHash -LiteralPath $archive -Algorithm SHA256).Hash
+    if (-not $existingHash.Equals(
+            $expectedArchiveSha256,
+            [StringComparison]::OrdinalIgnoreCase)) {
+        Remove-Item -LiteralPath $archive -Force
+    }
+}
+if (-not (Test-Path -LiteralPath $archive)) {
+    $url = "https://github.com/obsproject/obs-studio/archive/refs/tags/$version.zip"
+    Write-Host "Downloading OBS Studio $version public headers..."
+    Invoke-WebRequest -UseBasicParsing -Uri $url -OutFile $archive
+}
+$actualHash = (Get-FileHash -LiteralPath $archive -Algorithm SHA256).Hash
+if (-not $actualHash.Equals(
+        $expectedArchiveSha256,
+        [StringComparison]::OrdinalIgnoreCase)) {
+    Remove-Item -LiteralPath $archive -Force
+    throw "OBS source archive SHA-256 mismatch. Expected $expectedArchiveSha256; found $actualHash."
+}
+
+if (Test-Path -LiteralPath $Destination) {
+    Remove-Item -LiteralPath $Destination -Recurse -Force
+}
+$includeRoot = Join-Path $Destination "include"
+New-Item -ItemType Directory -Force -Path $includeRoot | Out-Null
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+$zip = [IO.Compression.ZipFile]::OpenRead($archive)
+try {
+    $prefix = "obs-studio-$version/libobs/"
+    foreach ($entry in $zip.Entries) {
+        if (-not $entry.FullName.StartsWith($prefix, [StringComparison]::Ordinal) -or
+            -not $entry.Name) {
+            continue
+        }
+        $relative = $entry.FullName.Substring($prefix.Length)
+        if ([IO.Path]::GetExtension($relative) -notin ".h", ".hpp") {
+            continue
+        }
+        $target = [IO.Path]::GetFullPath((Join-Path $includeRoot $relative))
+        $includePrefix = $includeRoot.TrimEnd(
+            [IO.Path]::DirectorySeparatorChar,
+            [IO.Path]::AltDirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar
+        if (-not $target.StartsWith(
+                $includePrefix,
+                [StringComparison]::OrdinalIgnoreCase)) {
+            throw "Unsafe OBS header archive entry: $($entry.FullName)"
+        }
+        $parent = Split-Path -Parent $target
+        New-Item -ItemType Directory -Force -Path $parent | Out-Null
+        [IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $target, $true)
+    }
+}
+finally {
+    $zip.Dispose()
+}
+
+if (-not (Test-Path -LiteralPath $header)) {
+    throw "obs-module.h was not extracted from the OBS source archive."
+}
+Set-Content -LiteralPath $generatedConfig -Encoding ascii -Value @(
+    "#pragma once",
+    "#define OBS_RELEASE_CANDIDATE 0",
+    "#define OBS_BETA 0"
+)
+Set-Content -LiteralPath $marker -Value $version -Encoding ascii
+Set-Content -LiteralPath $sourceHashMarker `
+    -Value $expectedArchiveSha256 -Encoding ascii
+Write-Host "OBS plugin headers $version ready: $Destination"

--- a/tools/BuildRelease.ps1
+++ b/tools/BuildRelease.ps1
@@ -80,6 +80,10 @@ if (-not (Test-Path -LiteralPath $captailExe)) {
 if (-not (Test-Path -LiteralPath (Join-Path $publishDirectory "obs.dll"))) {
     throw "Published OBS runtime not found."
 }
+if (-not (Test-Path -LiteralPath (
+        Join-Path $publishDirectory "obs-plugins\64bit\captail-process-audio.dll"))) {
+    throw "Published process-audio plugin not found."
+}
 if (-not (Test-Path -LiteralPath (Join-Path $publishDirectory "ffmpeg\ffmpeg.exe"))) {
     throw "Published FFmpeg runtime not found."
 }

--- a/tools/BuildStorePackage.ps1
+++ b/tools/BuildStorePackage.ps1
@@ -113,6 +113,7 @@ foreach ($requiredPath in @(
     (Join-Path $packageRoot "Captail.exe"),
     (Join-Path $packageRoot "CaptailObsBridge.dll"),
     (Join-Path $packageRoot "obs.dll"),
+    (Join-Path $packageRoot "obs-plugins\64bit\captail-process-audio.dll"),
     (Join-Path $packageRoot "libmpv-2.dll"),
     (Join-Path $packageRoot "ffmpeg\ffmpeg.exe"),
     (Join-Path $packageRoot "ffmpeg\ffprobe.exe"))) {

--- a/tools/ProcessAudioFoundationQa/ProcessAudioFoundationQa.csproj
+++ b/tools/ProcessAudioFoundationQa/ProcessAudioFoundationQa.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PlatformTarget>x64</PlatformTarget>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>ProcessAudioFoundationQa</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Captail\Captail.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/ProcessAudioFoundationQa/Program.cs
+++ b/tools/ProcessAudioFoundationQa/Program.cs
@@ -1,0 +1,476 @@
+using Captail;
+using Captail.Interop;
+using System.Text.Json;
+
+namespace ProcessAudioFoundationQa;
+
+internal static class Program
+{
+    private static int _passed;
+
+    private static int Main()
+    {
+        try
+        {
+            Run("normalized executable matching", NormalizedExecutableMatching);
+            Run("independent same-name roots", IndependentSameNameRoots);
+            Run("same-name descendant deduplication", SameNameDescendantDeduplication);
+            Run("global ancestor-wins deduplication", GlobalAncestorWins);
+            Run("PID reuse parent validation", PidReuseBreaksParentEdge);
+            Run("reconciler restart lifecycle", ReconcilerRestartLifecycle);
+            Run("reconciler overlapping roots", ReconcilerOverlappingRoots);
+            Run("reconciler failure isolation", ReconcilerFailureIsolation);
+            Run("reconciler thread ownership", ReconcilerThreadOwnership);
+            Run("reconciler clean shutdown", ReconcilerCleanShutdown);
+            Run("advanced config normalization", AdvancedConfigNormalization);
+            Run("config clone copy and equality", ConfigCloneCopyAndEquality);
+            Run("old config remains simple", OldConfigRemainsSimple);
+            Run("routing across tracks", RoutingAcrossTracks);
+            Run("mixer bits and encoder continuity", MixerBitsAndEncoderContinuity);
+            Run("simple audio topology regression", SimpleAudioTopologyRegression);
+            Run("polling reacquisition cadence", PollingReacquisitionCadence);
+            Run("advanced capability model", AdvancedCapabilityModel);
+            Run("advanced diagnostics privacy", AdvancedDiagnosticsPrivacy);
+            Console.WriteLine($"PASS {_passed} process audio foundation tests");
+            return 0;
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine(exception);
+            return 1;
+        }
+    }
+
+    private static void NormalizedExecutableMatching()
+    {
+        ProcessSnapshot snapshot = Snapshot(
+            Node(10, 100, 0, "Discord.exe"));
+        ProcessNode[] roots = snapshot
+            .SelectIndependentRoots([@"C:\Apps\DISCORD.EXE"])
+            .ToArray();
+        Equal(1, roots.Length);
+        Equal(10u, roots[0].Identity.ProcessId);
+    }
+
+    private static void IndependentSameNameRoots()
+    {
+        ProcessSnapshot snapshot = Snapshot(
+            Node(10, 100, 1, "browser.exe"),
+            Node(20, 200, 1, "browser.exe"));
+        ProcessNode[] roots = snapshot.SelectIndependentRoots(["browser.exe"]).ToArray();
+        SequenceEqual([10u, 20u], roots.Select(root => root.Identity.ProcessId));
+    }
+
+    private static void SameNameDescendantDeduplication()
+    {
+        ProcessSnapshot snapshot = Snapshot(
+            Node(10, 100, 1, "browser.exe"),
+            Node(11, 110, 10, "browser.exe"),
+            Node(12, 120, 11, "browser.exe"));
+        ProcessNode[] roots = snapshot.SelectIndependentRoots(["browser.exe"]).ToArray();
+        SequenceEqual([10u], roots.Select(root => root.Identity.ProcessId));
+    }
+
+    private static void GlobalAncestorWins()
+    {
+        ProcessSnapshot snapshot = Snapshot(
+            Node(10, 100, 1, "launcher.exe"),
+            Node(11, 110, 10, "game.exe"),
+            Node(12, 120, 11, "helper.exe"));
+        ProcessNode[] roots = snapshot
+            .SelectIndependentRoots(["helper.exe", "game.exe", "launcher.exe"])
+            .ToArray();
+        SequenceEqual([10u], roots.Select(root => root.Identity.ProcessId));
+    }
+
+    private static void PidReuseBreaksParentEdge()
+    {
+        ProcessSnapshot snapshot = Snapshot(
+            Node(10, 300, 1, "browser.exe"),
+            Node(11, 200, 10, "browser.exe"));
+        ProcessNode[] roots = snapshot.SelectIndependentRoots(["browser.exe"]).ToArray();
+        SequenceEqual([11u, 10u], roots.Select(root => root.Identity.ProcessId));
+    }
+
+    private static void ReconcilerRestartLifecycle()
+    {
+        var created = new List<ProcessIdentity>();
+        var destroyed = new List<nint>();
+        nint nextSource = 100;
+        using var reconciler = new ProcessAudioReconciler(
+            (identity, _) =>
+            {
+                created.Add(identity);
+                return nextSource++;
+            },
+            destroyed.Add);
+
+        ProcessAudioReconcileResult first = reconciler.Reconcile(
+            Snapshot(Node(10, 100, 1, "game.exe")),
+            [Target("game.exe", 1)]);
+        Equal(1, first.CreatedSources);
+
+        ProcessAudioReconcileResult second = reconciler.Reconcile(
+            Snapshot(Node(10, 200, 1, "game.exe")),
+            [Target("game.exe", 1)]);
+        Equal(1, second.DestroyedSources);
+        Equal(1, second.CreatedSources);
+        Equal(2, created.Count);
+        Equal(1, destroyed.Count);
+        Equal(200L, reconciler.ActiveIdentities.Single().CreationTime);
+    }
+
+    private static void ReconcilerFailureIsolation()
+    {
+        using var reconciler = new ProcessAudioReconciler(
+            (identity, _) => identity.ProcessId == 10
+                ? throw new InvalidOperationException("expected")
+                : checked((nint)identity.ProcessId),
+            _ => { });
+        ProcessAudioReconcileResult result = reconciler.Reconcile(
+            Snapshot(
+                Node(10, 100, 1, "game.exe"),
+                Node(20, 200, 1, "game.exe")),
+            [Target("game.exe", 1)]);
+        Equal(2, result.DesiredSources);
+        Equal(1, result.ActiveSources);
+        Equal(1, result.FailedSources);
+        Equal(20u, reconciler.ActiveIdentities.Single().ProcessId);
+    }
+
+    private static void ReconcilerOverlappingRoots()
+    {
+        using var reconciler = new ProcessAudioReconciler(
+            (identity, _) => checked((nint)identity.ProcessId),
+            _ => { });
+        ProcessAudioReconcileResult result = reconciler.Reconcile(
+            Snapshot(
+                Node(10, 100, 1, "launcher.exe"),
+                Node(11, 110, 10, "game.exe")),
+            [Target("launcher.exe", 2), Target("game.exe", 5)]);
+        Equal(1, result.ActiveSources);
+        Equal(10u, reconciler.ActiveIdentities.Single().ProcessId);
+        Equal(2, reconciler.ActiveTracks.Single().Value);
+    }
+
+    private static void ReconcilerThreadOwnership()
+    {
+        using var reconciler = new ProcessAudioReconciler(
+            (identity, _) => checked((nint)identity.ProcessId),
+            _ => { });
+        Exception? failure = Task.Run(() =>
+        {
+            try
+            {
+                reconciler.Reconcile(Snapshot(), []);
+                return null;
+            }
+            catch (Exception exception)
+            {
+                return exception;
+            }
+        }).GetAwaiter().GetResult();
+        if (failure is not InvalidOperationException)
+            throw new InvalidOperationException("A non-owner thread was not rejected.");
+    }
+
+    private static void ReconcilerCleanShutdown()
+    {
+        var destroyed = new List<nint>();
+        var reconciler = new ProcessAudioReconciler(
+            (identity, _) => checked((nint)identity.ProcessId),
+            destroyed.Add);
+        reconciler.Reconcile(
+            Snapshot(
+                Node(10, 100, 1, "game.exe"),
+                Node(20, 200, 1, "game.exe")),
+            [Target("game.exe", 1)]);
+        reconciler.Dispose();
+        Equal(2, destroyed.Count);
+        Equal(0, reconciler.ActiveIdentities.Count);
+    }
+
+    private static void AdvancedConfigNormalization()
+    {
+        var config = new Config
+        {
+            AudioRoutingMode = " ADVANCED ",
+            AdvancedMicrophoneTrack = 9,
+            ProcessAudioRoutes =
+            [
+                new() { Executable = @"C:\Apps\Discord.EXE", Track = 2 },
+                new() { Executable = "discord", Track = 5 },
+                new() { Executable = "FIREFOX", Track = 3 },
+                new() { Executable = "not-a-process.dll", Track = 1 },
+                new() { Executable = "ignored.exe", Track = 7 },
+                new() { Executable = "", Track = 1 },
+            ],
+        };
+        config.Normalize();
+
+        Equal("advanced", config.AudioRoutingMode);
+        Equal(1, config.AdvancedMicrophoneTrack);
+        Equal(2, config.ProcessAudioRoutes.Count);
+        Equal("discord.exe", config.ProcessAudioRoutes[0].Executable);
+        Equal(2, config.ProcessAudioRoutes[0].Track);
+        Equal("firefox.exe", config.ProcessAudioRoutes[1].Executable);
+        Equal(3, config.ProcessAudioRoutes[1].Track);
+    }
+
+    private static void ConfigCloneCopyAndEquality()
+    {
+        var source = new Config
+        {
+            AudioRoutingMode = "advanced",
+            AdvancedMicrophoneTrack = 4,
+            ProcessAudioRoutes =
+            [
+                new() { Executable = "Discord.exe", Track = 2 },
+                new() { Executable = "firefox", Track = 3 },
+            ],
+        };
+        source.Normalize();
+        Config clone = source.Clone();
+        if (!source.PipelineEquals(clone))
+            throw new InvalidOperationException("A normalized clone changed the pipeline.");
+        if (ReferenceEquals(source.ProcessAudioRoutes, clone.ProcessAudioRoutes))
+            throw new InvalidOperationException("Route lists were not deep-copied.");
+
+        clone.ProcessAudioRoutes[0].Track = 6;
+        if (source.PipelineEquals(clone))
+            throw new InvalidOperationException("A route change did not restart the pipeline.");
+
+        clone.CopyFrom(source);
+        clone.AdvancedMicrophoneTrack = 5;
+        if (source.PipelineEquals(clone))
+            throw new InvalidOperationException("A microphone route change was ignored.");
+
+        clone.CopyFrom(source);
+        clone.AudioRoutingMode = "simple";
+        if (source.PipelineEquals(clone))
+            throw new InvalidOperationException("A routing-mode change was ignored.");
+    }
+
+    private static void OldConfigRemainsSimple()
+    {
+        const string json = """
+            {
+              "CaptureSystemAudio": true,
+              "CaptureMicrophone": true,
+              "SeparateAudioTracks": true
+            }
+            """;
+        Config config = JsonSerializer.Deserialize<Config>(json)
+            ?? throw new InvalidOperationException("Old config did not deserialize.");
+        config.Normalize();
+        Equal("simple", config.AudioRoutingMode);
+        Equal(0, config.ProcessAudioRoutes.Count);
+        Equal(1, config.AdvancedMicrophoneTrack);
+        Equal(2, ObsReplayEngine.AudioTrackCount(config));
+
+        config.ProcessAudioRoutes = null!;
+        Config copied = config.Clone();
+        Equal(0, copied.ProcessAudioRoutes.Count);
+    }
+
+    private static void RoutingAcrossTracks()
+    {
+        var created = new List<(uint ProcessId, int Track)>();
+        var destroyed = new List<nint>();
+        using var reconciler = new ProcessAudioReconciler(
+            (identity, track) =>
+            {
+                created.Add((identity.ProcessId, track));
+                return checked((nint)identity.ProcessId);
+            },
+            destroyed.Add);
+        ProcessSnapshot snapshot = Snapshot(
+            Node(10, 100, 1, "discord.exe"),
+            Node(20, 200, 1, "firefox.exe"),
+            Node(30, 300, 1, "chrome.exe"),
+            Node(31, 310, 30, "chrome.exe"),
+            Node(40, 400, 1, "chrome.exe"));
+        ProcessAudioReconcileResult result = reconciler.Reconcile(
+            snapshot,
+            [
+                Target("discord.exe", 2),
+                Target("firefox.exe", 2),
+                Target("chrome.exe", 5),
+            ]);
+        Equal(4, result.ActiveSources);
+        SequenceEqual(
+            [(10u, 2), (20u, 2), (30u, 5), (40u, 5)],
+            created);
+
+        ProcessAudioReconcileResult changed = reconciler.Reconcile(
+            snapshot,
+            [
+                Target("discord.exe", 2),
+                Target("firefox.exe", 4),
+                Target("chrome.exe", 5),
+            ]);
+        Equal(1, changed.DestroyedSources);
+        Equal(1, changed.CreatedSources);
+        Equal(1, destroyed.Count);
+        Equal(4, reconciler.ActiveTracks.Single(item =>
+            item.Key.ProcessId == 20).Value);
+    }
+
+    private static void MixerBitsAndEncoderContinuity()
+    {
+        Equal(1u, ObsReplayEngine.MixerBit(1));
+        Equal(2u, ObsReplayEngine.MixerBit(2));
+        Equal(32u, ObsReplayEngine.MixerBit(6));
+
+        var config = new Config
+        {
+            AudioRoutingMode = "advanced",
+            CaptureMicrophone = true,
+            AdvancedMicrophoneTrack = 6,
+            ProcessAudioRoutes =
+            [
+                new() { Executable = "game.exe", Track = 1 },
+                new() { Executable = "chat.exe", Track = 4 },
+            ],
+        };
+        config.Normalize();
+        Equal(6, ObsReplayEngine.AudioTrackCount(config));
+
+        config.CaptureMicrophone = false;
+        Equal(4, ObsReplayEngine.AudioTrackCount(config));
+    }
+
+    private static void SimpleAudioTopologyRegression()
+    {
+        var config = new Config { AudioRoutingMode = "simple" };
+        config.CaptureSystemAudio = false;
+        config.CaptureMicrophone = false;
+        Equal(1, ObsReplayEngine.AudioTrackCount(config));
+        config.CaptureSystemAudio = true;
+        Equal(1, ObsReplayEngine.AudioTrackCount(config));
+        config.CaptureMicrophone = true;
+        Equal(1, ObsReplayEngine.AudioTrackCount(config));
+        config.SeparateAudioTracks = true;
+        Equal(2, ObsReplayEngine.AudioTrackCount(config));
+    }
+
+    private static void PollingReacquisitionCadence()
+    {
+        var cadence = new ProcessAudioPollCadence();
+        Equal(TimeSpan.FromMilliseconds(1000), cadence.NextInterval);
+        cadence.Observe(Result(desired: 0));
+        Equal(TimeSpan.FromMilliseconds(1000), cadence.NextInterval);
+        cadence.Observe(Result(desired: 1, created: 1));
+        Equal(TimeSpan.FromMilliseconds(250), cadence.NextInterval);
+        for (int poll = 0; poll < 7; poll++)
+        {
+            cadence.Observe(Result(desired: 1));
+            Equal(TimeSpan.FromMilliseconds(250), cadence.NextInterval);
+        }
+        cadence.Observe(Result(desired: 1));
+        Equal(TimeSpan.FromMilliseconds(1000), cadence.NextInterval);
+
+        cadence.Observe(Result(desired: 0, destroyed: 1));
+        Equal(TimeSpan.FromMilliseconds(250), cadence.NextInterval);
+    }
+
+    private static void AdvancedCapabilityModel()
+    {
+        Equal(
+            AdvancedProcessAudioAvailability.UnsupportedWindowsVersion,
+            ObsReplayEngine.DetectProcessAudioAvailability(
+                new Version(10, 0, 19040),
+                sourceRegistered: true));
+        Equal(
+            AdvancedProcessAudioAvailability.SourceUnavailable,
+            ObsReplayEngine.DetectProcessAudioAvailability(
+                new Version(10, 0, 19041),
+                sourceRegistered: false));
+        Equal(
+            AdvancedProcessAudioAvailability.Available,
+            ObsReplayEngine.DetectProcessAudioAvailability(
+                new Version(10, 0, 19041),
+                sourceRegistered: true));
+
+        var simple = new Config { AudioRoutingMode = "simple" };
+        var advanced = new Config { AudioRoutingMode = "advanced" };
+        if (!ObsReplayEngine.IsAudioRoutingAvailable(
+                simple,
+                AdvancedProcessAudioAvailability.UnsupportedWindowsVersion))
+        {
+            throw new InvalidOperationException(
+                "Unsupported process loopback disabled simple audio.");
+        }
+        if (ObsReplayEngine.IsAudioRoutingAvailable(
+                advanced,
+                AdvancedProcessAudioAvailability.SourceUnavailable))
+        {
+            throw new InvalidOperationException(
+                "Advanced audio was enabled without its OBS source.");
+        }
+    }
+
+    private static void AdvancedDiagnosticsPrivacy()
+    {
+        var config = new Config
+        {
+            AudioRoutingMode = "advanced",
+            ProcessAudioRoutes =
+            [
+                new() { Executable = "private-chat.exe", Track = 2 },
+                new() { Executable = "private-game.exe", Track = 4 },
+            ],
+        };
+        config.Normalize();
+        string summary = BugReportInfo.FormatAudio(config);
+        if (summary.Contains("private", StringComparison.OrdinalIgnoreCase) ||
+            summary.Contains(".exe", StringComparison.OrdinalIgnoreCase) ||
+            !summary.Contains("2 rules", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "Advanced diagnostics exposed a configured executable.");
+        }
+    }
+
+    private static ProcessAudioReconcileResult Result(
+        int desired,
+        int created = 0,
+        int destroyed = 0) =>
+        new(desired, desired, created, destroyed, 0);
+
+    private static ProcessAudioTarget Target(string executable, int track) =>
+        new(executable, track);
+
+    private static ProcessNode Node(
+        uint processId,
+        long creationTime,
+        uint parentProcessId,
+        string executable) =>
+        new(new ProcessIdentity(processId, creationTime), parentProcessId, executable);
+
+    private static ProcessSnapshot Snapshot(params ProcessNode[] nodes) =>
+        ProcessSnapshot.CreateSynthetic(nodes);
+
+    private static void Run(string name, Action test)
+    {
+        test();
+        _passed++;
+        Console.WriteLine($"PASS {name}");
+    }
+
+    private static void Equal<T>(T expected, T actual)
+    {
+        if (!EqualityComparer<T>.Default.Equals(expected, actual))
+            throw new InvalidOperationException($"Expected {expected}; found {actual}.");
+    }
+
+    private static void SequenceEqual<T>(IEnumerable<T> expected, IEnumerable<T> actual)
+    {
+        if (!expected.SequenceEqual(actual))
+        {
+            throw new InvalidOperationException(
+                $"Expected [{string.Join(", ", expected)}]; " +
+                $"found [{string.Join(", ", actual)}].");
+        }
+    }
+}

--- a/tools/ProcessAudioQa/ProcessAudioQa.csproj
+++ b/tools/ProcessAudioQa/ProcessAudioQa.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PlatformTarget>x64</PlatformTarget>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>ProcessAudioQa</AssemblyName>
+    <RootNamespace>ProcessAudioQa</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="Target\**\*.cs" />
+    <ProjectReference Include="..\..\src\Captail\Captail.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/ProcessAudioQa/Program.cs
+++ b/tools/ProcessAudioQa/Program.cs
@@ -1,0 +1,993 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using Captail;
+using Captail.Interop;
+
+namespace ProcessAudioQa;
+
+internal static class Program
+{
+    [STAThread]
+    private static int Main(string[] args)
+    {
+        try
+        {
+            Options options = Options.Parse(args);
+            Directory.CreateDirectory(options.OutputDirectory);
+
+            using var session = new ObsSession(options);
+            _ = options.Sources
+                .Select(source => session.CreateProbe(source, options.Frequencies))
+                .ToList();
+
+            Console.WriteLine($"READY elapsed_ms={session.ElapsedMilliseconds}");
+            long nextStatus = 1_000;
+            while (session.ElapsedMilliseconds < options.Duration.TotalMilliseconds)
+            {
+                Thread.Sleep(50);
+                session.RefreshWatchedProcesses();
+                if (session.ElapsedMilliseconds < nextStatus)
+                    continue;
+
+                foreach (AudioProbe probe in session.ActiveProbes)
+                    Console.WriteLine(probe.StatusLine(session.ElapsedMilliseconds));
+                nextStatus += 1_000;
+            }
+
+            QaReport report = session.CreateReport();
+            string reportPath = Path.Combine(options.OutputDirectory, options.ReportName);
+            File.WriteAllText(
+                reportPath,
+                JsonSerializer.Serialize(report, new JsonSerializerOptions { WriteIndented = true }));
+
+            foreach (AudioProbe probe in session.Probes)
+                probe.WriteWaveFile(options.OutputDirectory);
+
+            Console.WriteLine($"REPORT {reportPath}");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(ex);
+            return 1;
+        }
+    }
+}
+
+internal sealed record SourceRule(
+    string Label,
+    string Executable,
+    ProcessIdentity? Identity = null);
+
+internal sealed class Options
+{
+    internal required string RuntimeRoot { get; init; }
+    internal required string OutputDirectory { get; init; }
+    internal required string ReportName { get; init; }
+    internal required TimeSpan Duration { get; init; }
+    internal required IReadOnlyList<SourceRule> Sources { get; init; }
+    internal required IReadOnlyList<double> Frequencies { get; init; }
+    internal required IReadOnlyList<string> WatchedExecutables { get; init; }
+    internal long CreationTimeOffset { get; init; }
+    internal string? ProcessAudioPluginPath { get; init; }
+    internal string? LogBridgePath { get; init; }
+
+    internal static Options Parse(string[] args)
+    {
+        string repositoryRoot = FindRepositoryRoot();
+        string runtimeRoot = Path.Combine(repositoryRoot, "runtime", "obs");
+        string outputDirectory = Path.Combine(repositoryRoot, ".qa", "process-audio");
+        string reportName = $"report-{DateTime.Now:yyyyMMdd-HHmmss}.json";
+        TimeSpan duration = TimeSpan.FromSeconds(15);
+        var sources = new List<SourceRule>();
+        var frequencies = new List<double> { 440, 523.25, 659.25, 880, 997 };
+        var watchedExecutables = new List<string>();
+        string? bridgePath = null;
+        string? processAudioPluginPath = null;
+        long creationTimeOffset = 0;
+
+        for (int i = 0; i < args.Length; i++)
+        {
+            string value = NextValue(args, ref i);
+            switch (args[i - 1])
+            {
+                case "--runtime":
+                    runtimeRoot = Path.GetFullPath(value);
+                    break;
+                case "--output":
+                    outputDirectory = Path.GetFullPath(value);
+                    break;
+                case "--report":
+                    reportName = value;
+                    break;
+                case "--duration":
+                    duration = TimeSpan.FromSeconds(
+                        double.Parse(value, CultureInfo.InvariantCulture));
+                    break;
+                case "--source":
+                    int separator = value.IndexOf('=');
+                    if (separator <= 0 || separator == value.Length - 1)
+                        throw new ArgumentException("--source must be label=executable.exe");
+                    sources.Add(new SourceRule(value[..separator], value[(separator + 1)..]));
+                    break;
+                case "--frequency":
+                    frequencies.Add(double.Parse(value, CultureInfo.InvariantCulture));
+                    break;
+                case "--bridge":
+                    bridgePath = Path.GetFullPath(value);
+                    break;
+                case "--plugin":
+                    processAudioPluginPath = Path.GetFullPath(value);
+                    break;
+                case "--watch-executable":
+                    watchedExecutables.Add(value);
+                    break;
+                case "--creation-time-offset":
+                    creationTimeOffset = long.Parse(value, CultureInfo.InvariantCulture);
+                    break;
+                default:
+                    throw new ArgumentException($"Unknown argument: {args[i - 1]}");
+            }
+        }
+
+        if (sources.Count == 0 && watchedExecutables.Count == 0)
+        {
+            throw new ArgumentException(
+                "At least one --source or --watch-executable is required.");
+        }
+        if (!File.Exists(Path.Combine(runtimeRoot, "bin", "obs.dll")))
+            throw new FileNotFoundException("OBS runtime was not found.", runtimeRoot);
+        if (duration <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(duration));
+
+        return new Options
+        {
+            RuntimeRoot = runtimeRoot,
+            OutputDirectory = outputDirectory,
+            ReportName = reportName,
+            Duration = duration,
+            Sources = sources,
+            Frequencies = frequencies.Distinct().Order().ToArray(),
+            WatchedExecutables = watchedExecutables,
+            CreationTimeOffset = creationTimeOffset,
+            ProcessAudioPluginPath = processAudioPluginPath,
+            LogBridgePath = bridgePath,
+        };
+    }
+
+    private static string NextValue(string[] args, ref int index)
+    {
+        string name = args[index];
+        if (index + 1 >= args.Length)
+            throw new ArgumentException($"Missing value for {name}");
+        index++;
+        return args[index];
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Captail.sln")))
+                return directory.FullName;
+            directory = directory.Parent;
+        }
+
+        directory = new(Environment.CurrentDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Captail.sln")))
+                return directory.FullName;
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Captail repository root was not found.");
+    }
+}
+
+internal sealed class ObsSession : IDisposable
+{
+    private readonly Options _options;
+    private readonly Stopwatch _clock = Stopwatch.StartNew();
+    private readonly List<AudioProbe> _probes = [];
+    private readonly HashSet<nint> _activeProbeSources = [];
+    private readonly ConcurrentQueue<ObsLogEntry> _logs = new();
+    private readonly nint _dllDirectoryCookie;
+    private readonly nint _obsLibrary;
+    private readonly QaLogBridge? _logBridge;
+    private readonly ProcessAudioReconciler? _reconciler;
+    private long _nextReconcileMilliseconds;
+    private int _dynamicProbeNumber;
+    private bool _obsStarted;
+    private bool _disposed;
+
+    internal ObsSession(Options options)
+    {
+        _options = options;
+        string binDirectory = Path.Combine(options.RuntimeRoot, "bin");
+        NativeMethods.SetDefaultDllDirectories(
+            NativeMethods.LoadLibrarySearchDefaultDirs |
+            NativeMethods.LoadLibrarySearchUserDirs);
+        _dllDirectoryCookie = NativeMethods.AddDllDirectory(binDirectory);
+        if (_dllDirectoryCookie == 0)
+            throw new InvalidOperationException("Could not add the OBS runtime DLL directory.");
+
+        _obsLibrary = NativeLibrary.Load(Path.Combine(binDirectory, "obs.dll"));
+        NativeLibrary.SetDllImportResolver(
+            typeof(ObsNative).Assembly,
+            (libraryName, _, _) => string.Equals(
+                libraryName,
+                "obs.dll",
+                StringComparison.OrdinalIgnoreCase)
+                    ? _obsLibrary
+                    : 0);
+        if (!string.IsNullOrWhiteSpace(options.LogBridgePath))
+            _logBridge = new QaLogBridge(options.LogBridgePath, _clock, _logs);
+
+        string configDirectory = Path.Combine(options.OutputDirectory, "obs-config");
+        Directory.CreateDirectory(configDirectory);
+        _obsStarted = ObsNative.obs_startup("en-US", configDirectory, 0);
+        if (!_obsStarted)
+            throw new InvalidOperationException("obs_startup failed.");
+
+        string version = Marshal.PtrToStringUTF8(ObsNative.obs_get_version_string()) ?? "unknown";
+        Console.WriteLine($"OBS version={version}");
+
+        string dataRoot = Path.Combine(options.RuntimeRoot, "data");
+        ObsNative.obs_add_data_path(ToObsPath(Path.Combine(dataRoot, "libobs")) + "/");
+        ResetVideo(binDirectory);
+
+        var audio = new ObsNative.AudioInfo
+        {
+            SamplesPerSecond = 48_000,
+            Speakers = ObsNative.SpeakerLayout.Stereo,
+        };
+        if (!ObsNative.obs_reset_audio(ref audio))
+            throw new InvalidOperationException("obs_reset_audio failed.");
+
+        if (options.Sources.Count > 0)
+        {
+            LoadModule(
+                Path.Combine(options.RuntimeRoot, "obs-plugins", "64bit", "win-wasapi.dll"),
+                Path.Combine(dataRoot, "obs-plugins", "win-wasapi"));
+        }
+        if (options.WatchedExecutables.Count > 0)
+        {
+            if (string.IsNullOrWhiteSpace(options.ProcessAudioPluginPath) ||
+                !File.Exists(options.ProcessAudioPluginPath))
+            {
+                throw new FileNotFoundException(
+                    "The PID-aware OBS plugin was not found.",
+                    options.ProcessAudioPluginPath);
+            }
+            LoadModule(options.ProcessAudioPluginPath, options.OutputDirectory);
+        }
+        ObsNative.obs_post_load_modules();
+
+        if (options.Sources.Count > 0 &&
+            !HasInputType("wasapi_process_output_capture"))
+            throw new InvalidOperationException("wasapi_process_output_capture was not registered.");
+        if (options.WatchedExecutables.Count > 0)
+        {
+            if (!HasInputType("captail_process_audio_capture"))
+            {
+                throw new InvalidOperationException(
+                    "captail_process_audio_capture was not registered.");
+            }
+            _reconciler = new ProcessAudioReconciler(
+                CreatePidProbe,
+                DestroyProbe,
+                message => Console.WriteLine($"RECONCILE {message}"));
+        }
+    }
+
+    internal long ElapsedMilliseconds => _clock.ElapsedMilliseconds;
+    internal IReadOnlyList<AudioProbe> Probes => _probes;
+    internal IEnumerable<AudioProbe> ActiveProbes =>
+        _probes.Where(probe => _activeProbeSources.Contains(probe.Source));
+
+    internal void RefreshWatchedProcesses()
+    {
+        if (_reconciler is null ||
+            _clock.ElapsedMilliseconds < _nextReconcileMilliseconds)
+        {
+            return;
+        }
+
+        _nextReconcileMilliseconds = _clock.ElapsedMilliseconds + 250;
+        ProcessSnapshot snapshot = Task.Run(ProcessSnapshot.Capture)
+            .GetAwaiter()
+            .GetResult();
+        ProcessAudioReconcileResult result = _reconciler.Reconcile(
+            snapshot,
+            _options.WatchedExecutables.Select(executable =>
+                new ProcessAudioTarget(executable, 1)));
+        Console.WriteLine(
+            $"RECONCILE elapsed_ms={_clock.ElapsedMilliseconds} " +
+            $"desired={result.DesiredSources} active={result.ActiveSources} " +
+            $"created={result.CreatedSources} destroyed={result.DestroyedSources} " +
+            $"failed={result.FailedSources}");
+    }
+
+    internal AudioProbe CreateProbe(SourceRule rule, IReadOnlyList<double> frequencies)
+    {
+        nint settings = ObsNative.obs_data_create();
+        try
+        {
+            string sourceId;
+            if (rule.Identity is ProcessIdentity identity)
+            {
+                sourceId = "captail_process_audio_capture";
+                ObsNative.obs_data_set_int(settings, "target_pid", identity.ProcessId);
+                ObsNative.obs_data_set_int(
+                    settings,
+                    "target_creation_time",
+                    identity.CreationTime);
+            }
+            else
+            {
+                sourceId = "wasapi_process_output_capture";
+                ObsNative.obs_data_set_string(settings, "window", $"::{rule.Executable}");
+                ObsNative.obs_data_set_int(settings, "priority", 2);
+            }
+            nint source = ObsNative.obs_source_create(
+                sourceId,
+                $"Process Audio QA - {rule.Label}",
+                settings,
+                0);
+            if (source == 0)
+                throw new InvalidOperationException($"Could not create source for {rule.Executable}.");
+            if (rule.Identity is not null && !HasProcessAudioStatus(source))
+            {
+                ObsNative.obs_source_remove(source);
+                ObsNative.obs_source_release(source);
+                throw new InvalidOperationException("The PID-aware source rejected its identity.");
+            }
+
+            var probe = new AudioProbe(rule, source, _clock, frequencies);
+            _probes.Add(probe);
+            _activeProbeSources.Add(source);
+            ObsNative.obs_source_add_audio_capture_callback(source, probe.Callback, 0);
+            ObsNative.obs_source_inc_active(source);
+            return probe;
+        }
+        finally
+        {
+            ObsNative.obs_data_release(settings);
+        }
+    }
+
+    internal QaReport CreateReport() => new(
+        DateTimeOffset.Now,
+        Marshal.PtrToStringUTF8(ObsNative.obs_get_version_string()) ?? "unknown",
+        _clock.ElapsedMilliseconds,
+        _probes.Select(probe => probe.CreateResult()).ToArray(),
+        _logs.ToArray());
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+
+        _reconciler?.Dispose();
+        foreach (AudioProbe probe in Enumerable.Reverse(_probes))
+            DestroyProbe(probe.Source);
+        _probes.Clear();
+        Console.WriteLine($"CLEAN_SOURCES elapsed_ms={_clock.ElapsedMilliseconds}");
+
+        if (_obsStarted)
+        {
+            ObsNative.obs_wait_for_destroy_queue();
+            Console.WriteLine($"CLEAN_DESTROY_QUEUE elapsed_ms={_clock.ElapsedMilliseconds}");
+            ObsNative.obs_shutdown();
+            Console.WriteLine($"CLEAN_OBS_SHUTDOWN elapsed_ms={_clock.ElapsedMilliseconds}");
+            _obsStarted = false;
+        }
+
+        _logBridge?.Dispose();
+        Console.WriteLine($"CLEAN_LOG_BRIDGE elapsed_ms={_clock.ElapsedMilliseconds}");
+        NativeLibrary.Free(_obsLibrary);
+        if (_dllDirectoryCookie != 0)
+            NativeMethods.RemoveDllDirectory(_dllDirectoryCookie);
+        Console.WriteLine($"CLEAN elapsed_ms={_clock.ElapsedMilliseconds}");
+    }
+
+    private static bool HasInputType(string expected)
+    {
+        for (nuint index = 0; ObsNative.obs_enum_input_types(index, out nint id); index++)
+        {
+            if (string.Equals(Marshal.PtrToStringUTF8(id), expected, StringComparison.Ordinal))
+                return true;
+        }
+        return false;
+    }
+
+    private static bool HasProcessAudioStatus(nint source)
+    {
+        nint handler = ObsNative.obs_source_get_proc_handler(source);
+        if (handler == 0)
+            return false;
+
+        const int stackSize = 256;
+        nint stack = Marshal.AllocHGlobal(stackSize);
+        try
+        {
+            for (int offset = 0; offset < stackSize; offset += sizeof(long))
+                Marshal.WriteInt64(stack, offset, 0);
+            var callData = new ObsNative.CallData
+            {
+                Stack = stack,
+                Size = (nuint)nint.Size,
+                Capacity = stackSize,
+                Fixed = true,
+            };
+            return ObsNative.proc_handler_call(handler, "get_status", ref callData) &&
+                   ObsNative.calldata_get_data(
+                       ref callData,
+                       "state",
+                       out long _,
+                       sizeof(long));
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(stack);
+        }
+    }
+
+    private nint CreatePidProbe(ProcessIdentity identity, int _)
+    {
+        ProcessIdentity sourceIdentity = identity with
+        {
+            CreationTime = checked(identity.CreationTime + _options.CreationTimeOffset),
+        };
+        SourceRule rule = new(
+            $"pid-root-{++_dynamicProbeNumber}",
+            "pid-aware",
+            sourceIdentity);
+        return CreateProbe(rule, _options.Frequencies).Source;
+    }
+
+    private void DestroyProbe(nint source)
+    {
+        if (!_activeProbeSources.Remove(source))
+            return;
+        AudioProbe? probe = _probes.FirstOrDefault(candidate => candidate.Source == source);
+        if (probe is not null)
+        {
+            ObsNative.obs_source_remove_audio_capture_callback(
+                source,
+                probe.Callback,
+                0);
+            probe.MarkDestroyed();
+        }
+        ObsNative.obs_source_dec_active(source);
+        ObsNative.obs_source_remove(source);
+        ObsNative.obs_source_release(source);
+    }
+
+    private static void LoadModule(string modulePath, string dataPath)
+    {
+        int openResult = ObsNative.obs_open_module(
+            out nint module,
+            ToObsPath(modulePath),
+            ToObsPath(dataPath));
+        if (openResult != 0 || module == 0 || !ObsNative.obs_init_module(module))
+        {
+            throw new InvalidOperationException(
+                $"Could not load OBS module (result {openResult}).");
+        }
+    }
+
+    private static void ResetVideo(string binDirectory)
+    {
+        nint graphicsModule = Marshal.StringToCoTaskMemUTF8(
+            Path.Combine(binDirectory, "libobs-d3d11.dll"));
+        try
+        {
+            var video = new ObsNative.VideoInfo
+            {
+                GraphicsModule = graphicsModule,
+                FpsNum = 30,
+                FpsDen = 1,
+                BaseWidth = 640,
+                BaseHeight = 360,
+                OutputWidth = 640,
+                OutputHeight = 360,
+                OutputFormat = ObsNative.VideoFormat.Nv12,
+                Adapter = 0,
+                GpuConversion = true,
+                ColorSpace = ObsNative.VideoColorSpace.Cs709,
+                VideoRange = ObsNative.VideoRange.Partial,
+                ScaleType = ObsNative.ScaleType.Bilinear,
+            };
+            int result = ObsNative.obs_reset_video(ref video);
+            if (result != 0)
+                throw new InvalidOperationException($"obs_reset_video failed with code {result}.");
+        }
+        finally
+        {
+            Marshal.FreeCoTaskMem(graphicsModule);
+        }
+    }
+
+    private static string ToObsPath(string path) => path.Replace('\\', '/');
+}
+
+internal sealed class AudioProbe
+{
+    private const double SignalThreshold = 0.002;
+    private readonly object _gate = new();
+    private readonly Stopwatch _clock;
+    private readonly IReadOnlyList<double> _frequencies;
+    private readonly List<float[]> _blocks = [];
+    private readonly List<SignalInterval> _intervals = [];
+    private long? _firstCallbackMs;
+    private long? _firstSignalMs;
+    private long? _lastSignalMs;
+    private long _callbackBlocks;
+    private long _nonSilentBlocks;
+    private long _frames;
+    private double _maxRms;
+    private bool _destroyed;
+
+    internal AudioProbe(
+        SourceRule rule,
+        nint source,
+        Stopwatch clock,
+        IReadOnlyList<double> frequencies)
+    {
+        Rule = rule;
+        Source = source;
+        _clock = clock;
+        _frequencies = frequencies;
+        Callback = OnAudio;
+    }
+
+    internal SourceRule Rule { get; }
+    internal nint Source { get; }
+    internal ObsNative.AudioCaptureCallback Callback { get; }
+
+    internal string StatusLine(long elapsedMilliseconds)
+    {
+        lock (_gate)
+        {
+            return $"STATUS elapsed_ms={elapsedMilliseconds} label={Rule.Label} " +
+                   $"active={!_destroyed && ObsNative.obs_source_active(Source)} callbacks={_callbackBlocks} " +
+                   $"signal_blocks={_nonSilentBlocks} last_signal_ms={_lastSignalMs?.ToString() ?? "none"} " +
+                   $"max_rms={_maxRms:F6}";
+        }
+    }
+
+    internal ProbeResult CreateResult()
+    {
+        List<float[]> blocks;
+        lock (_gate)
+        {
+            blocks = [.. _blocks];
+            if (_lastSignalMs is long last &&
+                (_intervals.Count == 0 || _intervals[^1].EndMs is null))
+            {
+                SignalInterval open = _intervals[^1];
+                _intervals[^1] = open with { EndMs = last };
+            }
+        }
+
+        IReadOnlyDictionary<string, double> amplitudes = AnalyzeFrequencies(blocks, _frequencies);
+        lock (_gate)
+        {
+            return new ProbeResult(
+                Rule.Label,
+                Rule.Executable,
+                Rule.Identity?.ProcessId,
+                Rule.Identity?.CreationTime,
+                !_destroyed && ObsNative.obs_source_active(Source),
+                _firstCallbackMs,
+                _firstSignalMs,
+                _lastSignalMs,
+                _callbackBlocks,
+                _nonSilentBlocks,
+                _frames,
+                _maxRms,
+                [.. _intervals],
+                amplitudes);
+        }
+    }
+
+    internal void MarkDestroyed()
+    {
+        lock (_gate)
+            _destroyed = true;
+    }
+
+    internal void WriteWaveFile(string outputDirectory)
+    {
+        List<float[]> blocks;
+        lock (_gate)
+            blocks = [.. _blocks];
+        if (blocks.Count == 0)
+            return;
+
+        string safeLabel = string.Concat(Rule.Label.Select(
+            character => Path.GetInvalidFileNameChars().Contains(character) ? '_' : character));
+        string path = Path.Combine(outputDirectory, $"{safeLabel}.wav");
+        int sampleCount = blocks.Sum(block => block.Length);
+        using var stream = File.Create(path);
+        using var writer = new BinaryWriter(stream);
+        writer.Write("RIFF"u8);
+        writer.Write(36 + sampleCount * sizeof(float));
+        writer.Write("WAVE"u8);
+        writer.Write("fmt "u8);
+        writer.Write(16);
+        writer.Write((ushort)3);
+        writer.Write((ushort)1);
+        writer.Write(48_000);
+        writer.Write(48_000 * sizeof(float));
+        writer.Write((ushort)sizeof(float));
+        writer.Write((ushort)32);
+        writer.Write("data"u8);
+        writer.Write(sampleCount * sizeof(float));
+        foreach (float[] block in blocks)
+        {
+            foreach (float sample in block)
+                writer.Write(sample);
+        }
+    }
+
+    private void OnAudio(nint parameter, nint source, nint audioDataPointer, bool muted)
+    {
+        if (muted || audioDataPointer == 0)
+            return;
+
+        ObsNative.AudioData data = Marshal.PtrToStructure<ObsNative.AudioData>(audioDataPointer);
+        if (data.Data0 == 0 || data.Frames == 0 || data.Frames > 48_000)
+            return;
+
+        var samples = new float[data.Frames];
+        Marshal.Copy(data.Data0, samples, 0, samples.Length);
+        double sumSquares = 0;
+        foreach (float sample in samples)
+            sumSquares += sample * sample;
+        double rms = Math.Sqrt(sumSquares / samples.Length);
+        long elapsed = _clock.ElapsedMilliseconds;
+
+        lock (_gate)
+        {
+            _firstCallbackMs ??= elapsed;
+            _callbackBlocks++;
+            _frames += samples.Length;
+            _maxRms = Math.Max(_maxRms, rms);
+            _blocks.Add(samples);
+
+            if (rms < SignalThreshold)
+                return;
+
+            _firstSignalMs ??= elapsed;
+            _nonSilentBlocks++;
+            if (_lastSignalMs is null || elapsed - _lastSignalMs > 500)
+            {
+                if (_intervals.Count > 0 && _intervals[^1].EndMs is null)
+                    _intervals[^1] = _intervals[^1] with { EndMs = _lastSignalMs };
+                _intervals.Add(new SignalInterval(elapsed, null));
+            }
+            _lastSignalMs = elapsed;
+        }
+    }
+
+    private static IReadOnlyDictionary<string, double> AnalyzeFrequencies(
+        IReadOnlyList<float[]> blocks,
+        IReadOnlyList<double> frequencies)
+    {
+        var totals = frequencies.ToDictionary(frequency => frequency, _ => 0.0);
+        double normalization = 0;
+        foreach (float[] block in blocks)
+        {
+            if (block.Length == 0)
+                continue;
+            double windowSum = 0;
+            foreach (double frequency in frequencies)
+            {
+                double sin = 0;
+                double cos = 0;
+                double angular = 2 * Math.PI * frequency / 48_000;
+                for (int i = 0; i < block.Length; i++)
+                {
+                    double window = block.Length == 1
+                        ? 1
+                        : 0.5 - 0.5 * Math.Cos(2 * Math.PI * i / (block.Length - 1));
+                    sin += block[i] * window * Math.Sin(angular * i);
+                    cos += block[i] * window * Math.Cos(angular * i);
+                    if (frequency == frequencies[0])
+                        windowSum += window;
+                }
+                totals[frequency] += 2 * Math.Sqrt(sin * sin + cos * cos);
+            }
+            normalization += windowSum;
+        }
+
+        return totals.ToDictionary(
+            pair => pair.Key.ToString("0.##", CultureInfo.InvariantCulture),
+            pair => normalization == 0 ? 0 : pair.Value / normalization);
+    }
+}
+
+internal sealed class QaLogBridge : IDisposable
+{
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate bool InstallDelegate(LogCallback callback);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate void RemoveDelegate();
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate void LogCallback(int level, nint message);
+
+    private readonly nint _library;
+    private readonly Stopwatch _clock;
+    private readonly ConcurrentQueue<ObsLogEntry> _logs;
+    private readonly RemoveDelegate _remove;
+    private readonly LogCallback _callback;
+
+    internal QaLogBridge(
+        string path,
+        Stopwatch clock,
+        ConcurrentQueue<ObsLogEntry> logs)
+    {
+        _clock = clock;
+        _logs = logs;
+        _library = NativeLibrary.Load(path);
+        var install = Marshal.GetDelegateForFunctionPointer<InstallDelegate>(
+            NativeLibrary.GetExport(_library, "captail_install_obs_log_handler"));
+        _remove = Marshal.GetDelegateForFunctionPointer<RemoveDelegate>(
+            NativeLibrary.GetExport(_library, "captail_remove_obs_log_handler"));
+        _callback = OnLog;
+        if (!install(_callback))
+            throw new InvalidOperationException("Could not install the OBS log bridge.");
+    }
+
+    public void Dispose()
+    {
+        _remove();
+        NativeLibrary.Free(_library);
+    }
+
+    private void OnLog(int level, nint messagePointer)
+    {
+        string message = Marshal.PtrToStringUTF8(messagePointer) ?? string.Empty;
+        var entry = new ObsLogEntry(_clock.ElapsedMilliseconds, level, message);
+        _logs.Enqueue(entry);
+        if (message.Contains("WASAPI", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("process", StringComparison.OrdinalIgnoreCase))
+        {
+            Console.WriteLine(
+                $"OBS elapsed_ms={entry.ElapsedMs} level={level} message={message}");
+        }
+    }
+}
+
+internal sealed record SignalInterval(long StartMs, long? EndMs);
+internal sealed record ObsLogEntry(long ElapsedMs, int Level, string Message);
+internal sealed record ProbeResult(
+    string Label,
+    string Executable,
+    uint? ProcessId,
+    long? CreationTime,
+    bool ActiveAtEnd,
+    long? FirstCallbackMs,
+    long? FirstSignalMs,
+    long? LastSignalMs,
+    long CallbackBlocks,
+    long NonSilentBlocks,
+    long Frames,
+    double MaxRms,
+    IReadOnlyList<SignalInterval> SignalIntervals,
+    IReadOnlyDictionary<string, double> FrequencyAmplitudes);
+internal sealed record QaReport(
+    DateTimeOffset CreatedAt,
+    string ObsVersion,
+    long DurationMs,
+    IReadOnlyList<ProbeResult> Sources,
+    IReadOnlyList<ObsLogEntry> ObsLog);
+
+internal static class NativeMethods
+{
+    internal const uint LoadLibrarySearchDefaultDirs = 0x00001000;
+    internal const uint LoadLibrarySearchUserDirs = 0x00000400;
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool SetDefaultDllDirectories(uint directoryFlags);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    internal static extern nint AddDllDirectory(string newDirectory);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool RemoveDllDirectory(nint cookie);
+}
+
+internal static class ObsNative
+{
+    private const string Library = "obs.dll";
+
+    internal enum VideoFormat { None, I420, Nv12 }
+    internal enum VideoColorSpace { Default, Cs601, Cs709, Srgb }
+    internal enum VideoRange { Default, Partial, Full }
+    internal enum ScaleType { Disable, Point, Bicubic, Bilinear, Lanczos, Area }
+    internal enum SpeakerLayout { Unknown, Mono, Stereo }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct VideoInfo
+    {
+        internal nint GraphicsModule;
+        internal uint FpsNum;
+        internal uint FpsDen;
+        internal uint BaseWidth;
+        internal uint BaseHeight;
+        internal uint OutputWidth;
+        internal uint OutputHeight;
+        internal VideoFormat OutputFormat;
+        internal uint Adapter;
+        [MarshalAs(UnmanagedType.I1)] internal bool GpuConversion;
+        internal VideoColorSpace ColorSpace;
+        internal VideoRange VideoRange;
+        internal ScaleType ScaleType;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct AudioInfo
+    {
+        internal uint SamplesPerSecond;
+        internal SpeakerLayout Speakers;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct AudioData
+    {
+        internal nint Data0;
+        internal nint Data1;
+        internal nint Data2;
+        internal nint Data3;
+        internal nint Data4;
+        internal nint Data5;
+        internal nint Data6;
+        internal nint Data7;
+        internal uint Frames;
+        internal ulong Timestamp;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct CallData
+    {
+        internal nint Stack;
+        internal nuint Size;
+        internal nuint Capacity;
+        [MarshalAs(UnmanagedType.I1)] internal bool Fixed;
+    }
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate void AudioCaptureCallback(
+        nint parameter,
+        nint source,
+        nint audioData,
+        [MarshalAs(UnmanagedType.I1)] bool muted);
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    [return: MarshalAs(UnmanagedType.I1)]
+    internal static extern bool obs_startup(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string locale,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string moduleConfigPath,
+        nint profilerStore);
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void obs_shutdown();
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void obs_wait_for_destroy_queue();
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern nint obs_get_version_string();
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void obs_add_data_path(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string path);
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int obs_reset_video(ref VideoInfo videoInfo);
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    [return: MarshalAs(UnmanagedType.I1)]
+    internal static extern bool obs_reset_audio(ref AudioInfo audioInfo);
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int obs_open_module(
+        out nint module,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string binPath,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string dataPath);
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    [return: MarshalAs(UnmanagedType.I1)]
+    internal static extern bool obs_init_module(nint module);
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void obs_post_load_modules();
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    [return: MarshalAs(UnmanagedType.I1)]
+    internal static extern bool obs_enum_input_types(nuint index, out nint id);
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern nint obs_data_create();
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void obs_data_release(nint data);
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void obs_data_set_string(
+        nint data,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string name,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string value);
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void obs_data_set_int(
+        nint data,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string name,
+        long value);
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern nint obs_source_create(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string id,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string name,
+        nint settings,
+        nint hotkeyData);
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void obs_source_remove(nint source);
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void obs_source_release(nint source);
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void obs_source_inc_active(nint source);
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void obs_source_dec_active(nint source);
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern nint obs_source_get_proc_handler(nint source);
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    [return: MarshalAs(UnmanagedType.I1)]
+    internal static extern bool proc_handler_call(
+        nint handler,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string name,
+        ref CallData callData);
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    [return: MarshalAs(UnmanagedType.I1)]
+    internal static extern bool calldata_get_data(
+        ref CallData callData,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string name,
+        out long value,
+        nuint size);
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    [return: MarshalAs(UnmanagedType.I1)]
+    internal static extern bool obs_source_active(nint source);
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void obs_source_add_audio_capture_callback(
+        nint source,
+        AudioCaptureCallback callback,
+        nint parameter);
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void obs_source_remove_audio_capture_callback(
+        nint source,
+        AudioCaptureCallback callback,
+        nint parameter);
+}

--- a/tools/ProcessAudioQa/README.md
+++ b/tools/ProcessAudioQa/README.md
@@ -1,0 +1,55 @@
+# Process audio QA harness
+
+This directory contains development/QA infrastructure for process-audio
+capture. It is intentionally excluded from `Captail.sln` and does not change
+Captail's configuration, UI, encoders, or recording pipeline.
+
+`ProcessAudioQa` can load either bundled `win-wasapi.dll` sources or Captail's
+PID-aware source. In PID-aware mode it takes process snapshots off the QA OBS
+thread, reconciles independent roots by executable name on that thread, and
+records each root's PID and creation time. It collects float audio blocks,
+attach timing and optional OBS bridge logs, then writes a JSON report plus one
+mono float WAV file per source. `Target` is a controllable tone generator for
+process lifecycle, process-tree, same-name, and windowless tests.
+`tone.html` provides a user-gesture-controlled Web Audio tone for a real
+Chromium process tree.
+
+Example:
+
+```powershell
+dotnet build .\tools\ProcessAudioQa\Target\ProcessAudioQaTarget.csproj -c Release
+dotnet build .\tools\ProcessAudioQa\Target\Child\ProcessAudioQaChild.csproj -c Release
+dotnet build .\tools\ProcessAudioQa\ProcessAudioQa.csproj -c Release
+.\tools\ProcessAudioQa\bin\Release\net9.0-windows10.0.22621.0\win-x64\ProcessAudioQa.exe `
+  --source target=ProcessAudioQaTarget.exe --duration 15
+```
+
+PID-aware example:
+
+```powershell
+.\tools\ProcessAudioQa\bin\Release\net9.0-windows10.0.22621.0\win-x64\ProcessAudioQa.exe `
+  --watch-executable ProcessAudioQaTarget.exe `
+  --plugin .\native\ProcessAudio\build\Release\captail-process-audio.dll `
+  --duration 15
+```
+
+`--creation-time-offset 1` deliberately supplies a stale identity and verifies
+that the native source refuses to activate or retarget the PID.
+
+All reports, recordings, and OBS configuration are written below
+`.qa/process-audio`, which is ignored by Git.
+
+The Debug Captail build also accepts backend-only mux QA arguments. They do
+not add product UI or persisted test settings:
+
+```powershell
+Captail.exe --qa-codecs --qa-codec=h264 --qa-audio-codec=aac `
+  --qa-advanced-audio=ProcessAudioQaTarget.exe:2,ProcessAudioQaChild.exe:5 `
+  --qa-record-seconds=10
+```
+
+`--qa-advanced-mic-track=N` enables the default microphone on advanced track
+`N`. Use `ffprobe` on the resulting MP4/AAC or MKV/Opus replay to verify that
+audio encoders are continuous from track 1 through the highest configured
+track. Executable names supplied to these QA-only command-line arguments are
+not written by the product process-audio diagnostics.

--- a/tools/ProcessAudioQa/Target/Child/ProcessAudioQaChild.csproj
+++ b/tools/ProcessAudioQa/Target/Child/ProcessAudioQaChild.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PlatformTarget>x64</PlatformTarget>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWindowsForms>true</UseWindowsForms>
+    <AssemblyName>ProcessAudioQaChild</AssemblyName>
+    <RootNamespace>ProcessAudioQaTarget</RootNamespace>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Program.cs" Link="Program.cs" />
+    <PackageReference Include="NAudio" Version="2.3.0" />
+  </ItemGroup>
+
+</Project>

--- a/tools/ProcessAudioQa/Target/ProcessAudioQaTarget.csproj
+++ b/tools/ProcessAudioQa/Target/ProcessAudioQaTarget.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PlatformTarget>x64</PlatformTarget>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWindowsForms>true</UseWindowsForms>
+    <AssemblyName>ProcessAudioQaTarget</AssemblyName>
+    <RootNamespace>ProcessAudioQaTarget</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="Child\**\*.cs" />
+    <PackageReference Include="NAudio" Version="2.3.0" />
+  </ItemGroup>
+
+</Project>

--- a/tools/ProcessAudioQa/Target/Program.cs
+++ b/tools/ProcessAudioQa/Target/Program.cs
@@ -1,0 +1,160 @@
+using System.Diagnostics;
+using System.Globalization;
+using NAudio.Wave;
+using NAudio.Wave.SampleProviders;
+
+namespace ProcessAudioQaTarget;
+
+internal static class Program
+{
+    [STAThread]
+    private static void Main(string[] args)
+    {
+        TargetOptions options = TargetOptions.Parse(args);
+        using WaveOutEvent? output = options.Silent ? null : CreateTone(options.Frequency);
+        output?.Play();
+
+        if (options.NoWindow)
+        {
+            LaunchChild(options);
+            Thread.Sleep(options.Duration);
+            return;
+        }
+
+        ApplicationConfiguration.Initialize();
+        using var form = new Form
+        {
+            Text = $"Process Audio QA - {options.Frequency:0.##} Hz - PID {Environment.ProcessId}",
+            Width = 480,
+            Height = 150,
+            StartPosition = FormStartPosition.CenterScreen,
+        };
+        form.Controls.Add(new Label
+        {
+            AutoSize = true,
+            Left = 20,
+            Top = 30,
+            Text = options.Silent
+                ? $"Silent parent process, PID {Environment.ProcessId}"
+                : $"Playing {options.Frequency:0.##} Hz, PID {Environment.ProcessId}",
+        });
+
+        var timer = new System.Windows.Forms.Timer
+        {
+            Interval = (int)Math.Clamp(options.Duration.TotalMilliseconds, 1, int.MaxValue),
+        };
+        timer.Tick += (_, _) => form.Close();
+        form.Shown += (_, _) =>
+        {
+            LaunchChild(options);
+            timer.Start();
+        };
+        Application.Run(form);
+    }
+
+    private static WaveOutEvent CreateTone(double frequency)
+    {
+        var signal = new SignalGenerator(48_000, 2)
+        {
+            Frequency = frequency,
+            Gain = 0.12,
+            Type = SignalGeneratorType.Sin,
+        };
+        var output = new WaveOutEvent { DesiredLatency = 100 };
+        output.Init(signal);
+        return output;
+    }
+
+    private static void LaunchChild(TargetOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.ChildExecutable))
+            return;
+
+        string childArguments = FormattableString.Invariant(
+            $"--frequency {options.ChildFrequency} --duration {options.Duration.TotalSeconds}") +
+            (options.ChildNoWindow ? " --no-window" : string.Empty);
+        Process.Start(new ProcessStartInfo
+        {
+            FileName = options.ChildExecutable,
+            Arguments = childArguments,
+            UseShellExecute = false,
+        });
+    }
+}
+
+internal sealed class TargetOptions
+{
+    internal double Frequency { get; private init; } = 440;
+    internal TimeSpan Duration { get; private init; } = TimeSpan.FromSeconds(30);
+    internal bool NoWindow { get; private init; }
+    internal bool Silent { get; private init; }
+    internal string? ChildExecutable { get; private init; }
+    internal double ChildFrequency { get; private init; } = 880;
+    internal bool ChildNoWindow { get; private init; }
+
+    internal static TargetOptions Parse(string[] args)
+    {
+        double frequency = 440;
+        TimeSpan duration = TimeSpan.FromSeconds(30);
+        bool noWindow = false;
+        bool silent = false;
+        string? childExecutable = null;
+        double childFrequency = 880;
+        bool childNoWindow = false;
+
+        for (int i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--frequency":
+                    frequency = double.Parse(
+                        NextValue(args, ref i),
+                        CultureInfo.InvariantCulture);
+                    break;
+                case "--duration":
+                    duration = TimeSpan.FromSeconds(double.Parse(
+                        NextValue(args, ref i),
+                        CultureInfo.InvariantCulture));
+                    break;
+                case "--no-window":
+                    noWindow = true;
+                    break;
+                case "--silent":
+                    silent = true;
+                    break;
+                case "--child":
+                    childExecutable = Path.GetFullPath(NextValue(args, ref i));
+                    break;
+                case "--child-frequency":
+                    childFrequency = double.Parse(
+                        NextValue(args, ref i),
+                        CultureInfo.InvariantCulture);
+                    break;
+                case "--child-no-window":
+                    childNoWindow = true;
+                    break;
+                default:
+                    throw new ArgumentException($"Unknown argument: {args[i]}");
+            }
+        }
+
+        return new TargetOptions
+        {
+            Frequency = frequency,
+            Duration = duration,
+            NoWindow = noWindow,
+            Silent = silent,
+            ChildExecutable = childExecutable,
+            ChildFrequency = childFrequency,
+            ChildNoWindow = childNoWindow,
+        };
+    }
+
+    private static string NextValue(string[] args, ref int index)
+    {
+        if (index + 1 >= args.Length)
+            throw new ArgumentException($"Missing value for {args[index]}");
+        index++;
+        return args[index];
+    }
+}

--- a/tools/ProcessAudioQa/tone.html
+++ b/tools/ProcessAudioQa/tone.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<title>Captail process audio QA tone</title>
+<style>
+  body { font: 24px system-ui; margin: 48px; }
+  button { font: inherit; padding: 12px 24px; }
+</style>
+<h1>Captail process audio QA</h1>
+<p>Chrome tone: 659.25 Hz</p>
+<button id="toggle">Start tone</button>
+<script>
+  let context;
+  let oscillator;
+  let gain;
+  async function toggle(event) {
+    if (oscillator) {
+      oscillator.stop();
+      oscillator = null;
+      event.target.textContent = "Start tone";
+      return;
+    }
+
+    context ??= new AudioContext();
+    await context.resume();
+    oscillator = new OscillatorNode(context, { frequency: 659.25 });
+    gain = new GainNode(context, { gain: 0.08 });
+    oscillator.connect(gain).connect(context.destination);
+    oscillator.start();
+    event.target.textContent = "Stop tone";
+  }
+  document.querySelector("#toggle").addEventListener("click", toggle);
+  if (new URLSearchParams(location.search).has("autostart"))
+    toggle({ target: document.querySelector("#toggle") });
+</script>
+</html>


### PR DESCRIPTION
## scope

this draft implements the native foundation, backend routing, and persistent configuration logic for [issue #31](https://github.com/FaulMit/captail/issues/31).

wpf/xaml ui and localization are intentionally excluded because the maintainer requested that work separately. this draft is not finished or ready to merge; maintainer testing and feedback on the backend/runtime behavior are requested before the user-facing routing work starts.

## what changed

- adds persistent normalized executable-basename -> track routing configuration for tracks 1-6
- identifies processes by `(pid, creation time)`, filters to the current user session, validates parent relationships, and selects independent roots with deterministic ancestor-wins deduplication
- reconciles appearing, exiting, and restarted process trees without allowing overlapping captured roots
- adds a minimal pid-aware obs input plugin using windows process loopback with `PROCESS_LOOPBACK_MODE_INCLUDE_TARGET_PROCESS_TREE`
- keeps process snapshots off the obs thread while serializing source creation/destruction on captail's existing obs scheduler
- uses 1000 ms steady polling and a temporary 250 ms reacquisition cadence after lifecycle changes
- routes each process root to its configured mixer bit and maintains continuous encoder topology through the highest used track (1-6)
- supports advanced microphone routing to a selected track
- isolates the Windows 10 2004 process-loopback requirement to the advanced capability path without changing captail's global minimum Windows version or simple-mode behavior
- keeps product diagnostics aggregate-only: configured executable names, pids, creation times, and local paths are not emitted
- pins the OBS Studio 32.1.2 public source archive by sha-256 for headers/import-library generation and documents the narrow `win-wasapi` provenance and GPL attribution

## validation

- release build with warnings as errors: 0 warnings, 0 errors
- formatting/analyzers: clean for the solution and both process-audio qa projects
- synthetic foundation suite: 19/19 passed, including pid reuse, restart, ancestor-wins overlap, failure isolation, config compatibility, mixer bits, simple-mode topology, cadence, capability handling, and diagnostics privacy
- multiple independent no-window processes with the same executable captured simultaneously into one configured track
- parent + child requested together produced one independent root; child audio was captured without duplicate sources
- process exit/restart destroyed the old `(pid, creation time)` source and created a new source automatically during the 250 ms reacquisition window
- stale creation-time identity was rejected without retargeting or stopping the replay pipeline
- target exit and clean source/destroy-queue/obs shutdown completed without a hang
- mp4/aac: video plus 3 continuous audio tracks; the two same-name processes were present on track 3 and unused tracks stayed silent
- mkv/opus: video plus 5 continuous audio tracks; independent targets were isolated to tracks 2 and 5 and gap tracks stayed silent
- advanced microphone routing to track 4 produced the expected continuous 1-4 encoder topology
- simple-mode regression produced the existing two-track system-audio + microphone topology
- portable release built successfully and contains the source-built process-audio plugin
- Microsoft Store package built and extracted successfully; native dependency, FFmpeg isolation, lifecycle, and asset checks passed, and capabilities remain `runFullTrust` plus `microphone`

## known limitations

- executable rules intentionally match normalized basenames, so two unrelated applications with the same basename cannot be routed differently
- inaccessible/protected processes are skipped until a later snapshot can identify them
- steady-state discovery can take up to 1000 ms; the 250 ms cadence is temporary and only used around reacquisition
- process loopback requires Windows 10 build 19041 or newer and can still fail per source because of OS/audio-subsystem conditions; failures remain isolated
- continuous encoders intentionally create silent gap tracks when a higher-numbered track is configured
- this draft has no settings ui, localization, migration wizard, or user-facing rule editor

please test this draft with representative real applications (especially discord, chromium-family multi-process applications, games/launchers, restarts, and Store installs) and provide feedback on the process-root and routing behavior. it should not be treated as ready to merge yet.
